### PR TITLE
Hotfix: stabilize annotation PDF page sync in UI

### DIFF
--- a/08_working_scratch/phase3b/scripts/annotation_ui.py
+++ b/08_working_scratch/phase3b/scripts/annotation_ui.py
@@ -68,6 +68,22 @@ def _header_lines(payload: dict) -> list[dict]:
     return [line for line in values if isinstance(line, dict)]
 
 
+def _body_lines(payload: dict) -> list[dict]:
+    regions = payload.get("regions", {})
+    values = regions.get("body", [])
+    if not isinstance(values, list):
+        return []
+    return [line for line in values if isinstance(line, dict)]
+
+
+def _opposite_side(side: str) -> str:
+    if side == "left":
+        return "right"
+    if side == "right":
+        return "left"
+    return ""
+
+
 def _side_for_header_index(index: int, total: int) -> str:
     if total < 2:
         return "unknown"
@@ -117,6 +133,7 @@ def _parse_side(value: object, default: str = "") -> str:
 def _refresh_meta_flags(payload: dict) -> None:
     lines = _all_lines(payload)
     header_lines = _header_lines(payload)
+    body_lines = _body_lines(payload)
     ae_pattern = re.compile(r"(ae|AE|æ|Æ)")
     marker_pattern = re.compile(r"\[[^\]]+\]|\bfn\d+\b|[\*†‡]")
 
@@ -140,10 +157,12 @@ def _refresh_meta_flags(payload: dict) -> None:
     contains_header_page_number = False
     contains_header_chapter_number = False
 
-    total_header = len(header_lines)
-    for index, line in enumerate(header_lines):
+    # Prefer explicit header region; if absent, scan first body lines where seeded OCR often keeps header text.
+    candidate_lines = header_lines if header_lines else body_lines[:2]
+    total_candidates = len(candidate_lines)
+    for index, line in enumerate(candidate_lines):
         text = str(line.get("text_gold", ""))
-        side = _side_for_header_index(index, total_header)
+        side = _side_for_header_index(index, total_candidates)
 
         if page_num is not None and _contains_page_number_token(text, page_num):
             contains_header_page_number = True
@@ -159,6 +178,14 @@ def _refresh_meta_flags(payload: dict) -> None:
     if contains_header_page_number and header_page_number_side == "" and expected_side:
         # Fallback to known layout rule when side is not inferable from header line structure.
         header_page_number_side = expected_side
+
+    if (
+        contains_header_chapter_number
+        and header_chapter_side == ""
+        and header_page_number_side in {"left", "right"}
+    ):
+        # Based on page design, chapter indicator appears opposite the page number.
+        header_chapter_side = _opposite_side(header_page_number_side)
 
     header_parity_consistent = bool(
         contains_header_page_number
@@ -190,12 +217,16 @@ def _refresh_meta_flags(payload: dict) -> None:
 
         if field_type == "bool":
             default_value = bool(derived_values[key])
-            parsed_value = _parse_bool(meta.get(value_key, default_value), default=default_value)
+            parsed_value = _parse_bool(
+                meta.get(value_key, default_value), default=default_value
+            )
             meta[value_key] = parsed_value
             meta[key] = parsed_value if enabled else default_value
         else:
             default_value = _parse_side(derived_values[key], default="")
-            parsed_value = _parse_side(meta.get(value_key, default_value), default=default_value)
+            parsed_value = _parse_side(
+                meta.get(value_key, default_value), default=default_value
+            )
             meta[value_key] = parsed_value
             meta[key] = parsed_value if enabled else default_value
 

--- a/08_working_scratch/phase3b/ui/static/annotation_ui.js
+++ b/08_working_scratch/phase3b/ui/static/annotation_ui.js
@@ -1,5 +1,6 @@
 let currentPayload = null;
 let activeInput = null;
+let currentPdfSource = "";
 const DEFAULT_REVIEWER = "Paul Boys";
 
 const pageSelect = document.getElementById("pageSelect");
@@ -660,7 +661,23 @@ async function loadPage(pageId) {
     applyDefaultReviewer(currentPayload);
     bindMeta(currentPayload.meta || (currentPayload.meta = {}));
     renderAllRegions();
-    pdfFrame.src = `/pdf/${pageId}`;
+
+    const parsedPageNum = Number(currentPayload.page_num);
+    const fallbackPageNum = Number(String(pageId || "").replace(/^p/, ""));
+    const pdfPageNum = Number.isFinite(parsedPageNum) && parsedPageNum > 0
+      ? parsedPageNum
+      : (Number.isFinite(fallbackPageNum) && fallbackPageNum > 0 ? fallbackPageNum : 1);
+
+    const sourcePdfKey = String(currentPayload.source_pdf || "");
+    if (!pdfFrame.src || currentPdfSource !== sourcePdfKey) {
+      // New source PDF: load it fresh at the target page.
+      currentPdfSource = sourcePdfKey;
+      pdfFrame.src = `/pdf/${pageId}#page=${pdfPageNum}`;
+    } else {
+      // Same source PDF: update only the page fragment to avoid full reload resets.
+      const currentBase = pdfFrame.src.split("#")[0];
+      pdfFrame.src = `${currentBase}#page=${pdfPageNum}`;
+    }
     setStatus(`Loaded ${pageId}`);
   } catch (err) {
     setStatus(String(err), true);


### PR DESCRIPTION
This PR applies the latest annotation UI hotfix directly on top of `main` to avoid the current `dev -> main` merge conflicts.

## What it fixes
- Improves automatic header indicator detection by falling back to top body lines when header lines are empty.
- Improves PDF navigation behavior in the annotation UI so page sync is more stable.

## Scope
- Cherry-picks commit `4fcb19c` onto a clean branch from `main`.
- Files changed:
  - `08_working_scratch/phase3b/scripts/annotation_ui.py`
  - `08_working_scratch/phase3b/ui/static/annotation_ui.js`

This is intentionally narrow and conflict-free relative to `main`.