### PR TITLE
Hotfix/pdfjs page sync main

### DIFF
--- a/08_working_scratch/phase3b/scripts/annotation_ui.py
+++ b/08_working_scratch/phase3b/scripts/annotation_ui.py
@@ -68,6 +68,22 @@ def _header_lines(payload: dict) -> list[dict]:
     return [line for line in values if isinstance(line, dict)]
 
 
+def _body_lines(payload: dict) -> list[dict]:
+    regions = payload.get("regions", {})
+    values = regions.get("body", [])
+    if not isinstance(values, list):
+        return []
+    return [line for line in values if isinstance(line, dict)]
+
+
+def _opposite_side(side: str) -> str:
+    if side == "left":
+        return "right"
+    if side == "right":
+        return "left"
+    return ""
+
+
 def _side_for_header_index(index: int, total: int) -> str:
     if total < 2:
         return "unknown"
@@ -117,6 +133,7 @@ def _parse_side(value: object, default: str = "") -> str:
 def _refresh_meta_flags(payload: dict) -> None:
     lines = _all_lines(payload)
     header_lines = _header_lines(payload)
+    body_lines = _body_lines(payload)
     ae_pattern = re.compile(r"(ae|AE|æ|Æ)")
     marker_pattern = re.compile(r"\[[^\]]+\]|\bfn\d+\b|[\*†‡]")
 
@@ -140,10 +157,12 @@ def _refresh_meta_flags(payload: dict) -> None:
     contains_header_page_number = False
     contains_header_chapter_number = False
 
-    total_header = len(header_lines)
-    for index, line in enumerate(header_lines):
+    # Prefer explicit header region; if absent, scan first body lines where seeded OCR often keeps header text.
+    candidate_lines = header_lines if header_lines else body_lines[:2]
+    total_candidates = len(candidate_lines)
+    for index, line in enumerate(candidate_lines):
         text = str(line.get("text_gold", ""))
-        side = _side_for_header_index(index, total_header)
+        side = _side_for_header_index(index, total_candidates)
 
         if page_num is not None and _contains_page_number_token(text, page_num):
             contains_header_page_number = True
@@ -159,6 +178,14 @@ def _refresh_meta_flags(payload: dict) -> None:
     if contains_header_page_number and header_page_number_side == "" and expected_side:
         # Fallback to known layout rule when side is not inferable from header line structure.
         header_page_number_side = expected_side
+
+    if (
+        contains_header_chapter_number
+        and header_chapter_side == ""
+        and header_page_number_side in {"left", "right"}
+    ):
+        # Based on page design, chapter indicator appears opposite the page number.
+        header_chapter_side = _opposite_side(header_page_number_side)
 
     header_parity_consistent = bool(
         contains_header_page_number
@@ -190,12 +217,16 @@ def _refresh_meta_flags(payload: dict) -> None:
 
         if field_type == "bool":
             default_value = bool(derived_values[key])
-            parsed_value = _parse_bool(meta.get(value_key, default_value), default=default_value)
+            parsed_value = _parse_bool(
+                meta.get(value_key, default_value), default=default_value
+            )
             meta[value_key] = parsed_value
             meta[key] = parsed_value if enabled else default_value
         else:
             default_value = _parse_side(derived_values[key], default="")
-            parsed_value = _parse_side(meta.get(value_key, default_value), default=default_value)
+            parsed_value = _parse_side(
+                meta.get(value_key, default_value), default=default_value
+            )
             meta[value_key] = parsed_value
             meta[key] = parsed_value if enabled else default_value
 

--- a/08_working_scratch/phase3b/scripts/annotation_ui.py
+++ b/08_working_scratch/phase3b/scripts/annotation_ui.py
@@ -3,7 +3,7 @@ import re
 import tempfile
 from pathlib import Path
 
-from flask import Flask, abort, jsonify, render_template, request, send_file
+from flask import Flask, abort, jsonify, render_template, request, send_file, url_for
 
 ROOT = Path(__file__).resolve().parents[3]
 PHASE3B_ROOT = ROOT / "08_working_scratch" / "phase3b"
@@ -48,6 +48,18 @@ def _write_payload_atomic(path: Path, payload: dict) -> None:
         handle.write("\n")
         temp_name = handle.name
     Path(temp_name).replace(path)
+
+
+def _resolve_source_pdf(payload: dict) -> tuple[Path, str]:
+    source_pdf_value = str(payload.get("source_pdf", "")).strip()
+    source_pdf = Path(source_pdf_value)
+    if not source_pdf.is_absolute():
+        candidates = [
+            ROOT / source_pdf,
+            ROOT / "00_source_pdf" / source_pdf_value,
+        ]
+        source_pdf = next((candidate for candidate in candidates if candidate.exists()), source_pdf)
+    return source_pdf, source_pdf_value
 
 
 def _all_lines(payload: dict) -> list[dict]:
@@ -351,21 +363,42 @@ def page_pdf(page_id: str):
         abort(404)
 
     payload = _read_payload(path)
-    source_pdf_value = str(payload.get("source_pdf", "")).strip()
-    source_pdf = Path(source_pdf_value)
-    if not source_pdf.is_absolute():
-        candidates = [
-            ROOT / source_pdf,
-            ROOT / "00_source_pdf" / source_pdf_value,
-        ]
-        source_pdf = next(
-            (candidate for candidate in candidates if candidate.exists()), source_pdf
-        )
+    source_pdf, source_pdf_value = _resolve_source_pdf(payload)
 
     if not source_pdf.exists():
         return f"Source PDF not found: {source_pdf_value}", 404
 
     return send_file(source_pdf)
+
+
+@app.get("/pdfjs/<page_id>")
+def pdfjs_viewer(page_id: str):
+    try:
+        path = _annotation_path(page_id)
+    except ValueError:
+        abort(400)
+
+    if not path.exists():
+        abort(404)
+
+    payload = _read_payload(path)
+    source_pdf, source_pdf_value = _resolve_source_pdf(payload)
+    if not source_pdf.exists():
+        return f"Source PDF not found: {source_pdf_value}", 404
+
+    requested_page = request.args.get("page", default="", type=str)
+    try:
+        initial_page = int(requested_page)
+    except (TypeError, ValueError):
+        initial_page = int(payload.get("page_num", 1) or 1)
+    if initial_page < 1:
+        initial_page = 1
+
+    return render_template(
+        "pdf_viewer.html",
+        pdf_url=url_for("page_pdf", page_id=page_id),
+        initial_page=initial_page,
+    )
 
 
 if __name__ == "__main__":

--- a/08_working_scratch/phase3b/ui/static/annotation_ui.js
+++ b/08_working_scratch/phase3b/ui/static/annotation_ui.js
@@ -670,13 +670,12 @@ async function loadPage(pageId) {
 
     const sourcePdfKey = String(currentPayload.source_pdf || "");
     if (!pdfFrame.src || currentPdfSource !== sourcePdfKey) {
-      // New source PDF: load it fresh at the target page.
+      // New source PDF: load dedicated PDF.js viewer at target page.
       currentPdfSource = sourcePdfKey;
-      pdfFrame.src = `/pdf/${pageId}#page=${pdfPageNum}`;
+      pdfFrame.src = `/pdfjs/${pageId}?page=${pdfPageNum}#page=${pdfPageNum}`;
     } else {
-      // Same source PDF: update only the page fragment to avoid full reload resets.
-      const currentBase = pdfFrame.src.split("#")[0];
-      pdfFrame.src = `${currentBase}#page=${pdfPageNum}`;
+      // Same source PDF: keep viewer loaded and instruct it to switch pages.
+      pdfFrame.contentWindow?.postMessage({ type: "setPage", page: pdfPageNum }, window.location.origin);
     }
     setStatus(`Loaded ${pageId}`);
   } catch (err) {

--- a/08_working_scratch/phase3b/ui/static/annotation_ui.js
+++ b/08_working_scratch/phase3b/ui/static/annotation_ui.js
@@ -1,5 +1,6 @@
 let currentPayload = null;
 let activeInput = null;
+let currentPdfSource = "";
 const DEFAULT_REVIEWER = "Paul Boys";
 
 const pageSelect = document.getElementById("pageSelect");
@@ -660,7 +661,23 @@ async function loadPage(pageId) {
     applyDefaultReviewer(currentPayload);
     bindMeta(currentPayload.meta || (currentPayload.meta = {}));
     renderAllRegions();
-    pdfFrame.src = `/pdf/${pageId}`;
+
+    const parsedPageNum = Number(currentPayload.page_num);
+    const fallbackPageNum = Number(String(pageId || "").replace(/^p/, ""));
+    const pdfPageNum = Number.isFinite(parsedPageNum) && parsedPageNum > 0
+      ? parsedPageNum
+      : (Number.isFinite(fallbackPageNum) && fallbackPageNum > 0 ? fallbackPageNum : 1);
+
+    const sourcePdfKey = String(currentPayload.source_pdf || "");
+    if (!pdfFrame.src || currentPdfSource !== sourcePdfKey) {
+      // New source PDF: load it fresh at the target page.
+      currentPdfSource = sourcePdfKey;
+      pdfFrame.src = `/pdf/${pageId}#page=${pdfPageNum}`;
+    } else {
+      // Same source PDF: update only the page fragment to avoid full reload resets.
+      const currentBase = pdfFrame.src.split("#")[0];
+      pdfFrame.src = `${currentBase}#page=${pdfPageNum}`;
+    }
     setStatus(`Loaded ${pageId}`);
   } catch (err) {
     setStatus(String(err), true);

--- a/08_working_scratch/phase3b/ui/templates/pdf_viewer.html
+++ b/08_working_scratch/phase3b/ui/templates/pdf_viewer.html
@@ -1,0 +1,189 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>PDF Viewer</title>
+  <style>
+    html, body {
+      margin: 0;
+      padding: 0;
+      width: 100%;
+      height: 100%;
+      background: #f5f1e8;
+      overflow: hidden;
+      font-family: "Source Serif 4", Georgia, serif;
+    }
+    .viewer-root {
+      height: 100%;
+      display: grid;
+      grid-template-rows: auto 1fr;
+    }
+    .toolbar {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      padding: 0.35rem 0.5rem;
+      border-bottom: 1px solid #d7cbb8;
+      background: #fff9ee;
+      font-size: 0.85rem;
+    }
+    .toolbar button,
+    .toolbar input {
+      border: 1px solid #c7b79f;
+      border-radius: 4px;
+      background: #fff;
+      padding: 0.2rem 0.4rem;
+      font-size: 0.85rem;
+    }
+    .toolbar input {
+      width: 4.5rem;
+      text-align: center;
+    }
+    .stage {
+      overflow: auto;
+      display: flex;
+      justify-content: center;
+      padding: 0.5rem;
+    }
+    canvas {
+      box-shadow: 0 0 0 1px #d7cbb8;
+      background: #fff;
+    }
+  </style>
+</head>
+<body>
+  <div class="viewer-root">
+    <div class="toolbar">
+      <button id="prevBtn" type="button" title="Previous page">Prev</button>
+      <label>
+        Page
+        <input id="pageInput" type="number" min="1" step="1">
+      </label>
+      <span id="pageInfo"></span>
+      <button id="nextBtn" type="button" title="Next page">Next</button>
+    </div>
+    <div class="stage">
+      <canvas id="pdfCanvas"></canvas>
+    </div>
+  </div>
+
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.11.174/pdf.min.js"></script>
+  <script>
+    const pdfUrl = {{ pdf_url|tojson }};
+    let currentPage = Number({{ initial_page|int }}) || 1;
+    let pdfDoc = null;
+    let renderToken = 0;
+
+    const canvas = document.getElementById("pdfCanvas");
+    const ctx = canvas.getContext("2d", { alpha: false });
+    const pageInput = document.getElementById("pageInput");
+    const pageInfo = document.getElementById("pageInfo");
+    const prevBtn = document.getElementById("prevBtn");
+    const nextBtn = document.getElementById("nextBtn");
+
+    function clampPage(pageNum) {
+      if (!pdfDoc) return 1;
+      return Math.max(1, Math.min(pdfDoc.numPages, Number(pageNum) || 1));
+    }
+
+    function updateControls() {
+      if (!pdfDoc) return;
+      pageInput.value = String(currentPage);
+      pageInfo.textContent = `of ${pdfDoc.numPages}`;
+      prevBtn.disabled = currentPage <= 1;
+      nextBtn.disabled = currentPage >= pdfDoc.numPages;
+    }
+
+    async function renderPage(pageNum) {
+      if (!pdfDoc) return;
+      currentPage = clampPage(pageNum);
+      updateControls();
+
+      const token = ++renderToken;
+      const page = await pdfDoc.getPage(currentPage);
+      const viewport = page.getViewport({ scale: 1.25 });
+      canvas.width = Math.ceil(viewport.width);
+      canvas.height = Math.ceil(viewport.height);
+
+      await page.render({
+        canvasContext: ctx,
+        viewport,
+      }).promise;
+
+      if (token !== renderToken) {
+        return;
+      }
+
+      // Keep iframe URL hash in sync so refresh/open-in-new-tab preserves the page.
+      if (location.hash !== `#page=${currentPage}`) {
+        history.replaceState(null, "", `#page=${currentPage}`);
+      }
+    }
+
+    function fallbackToNativePdf(pageNum) {
+      window.location.replace(`${pdfUrl}#page=${pageNum}`);
+    }
+
+    async function loadPdf(targetPage) {
+      if (!window.pdfjsLib) {
+        fallbackToNativePdf(targetPage);
+        return;
+      }
+
+      pdfjsLib.GlobalWorkerOptions.workerSrc = "https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.11.174/pdf.worker.min.js";
+      const loadingTask = pdfjsLib.getDocument({ url: pdfUrl, withCredentials: false });
+      pdfDoc = await loadingTask.promise;
+      await renderPage(targetPage);
+    }
+
+    prevBtn.addEventListener("click", () => {
+      if (currentPage > 1) {
+        renderPage(currentPage - 1);
+      }
+    });
+
+    nextBtn.addEventListener("click", () => {
+      if (pdfDoc && currentPage < pdfDoc.numPages) {
+        renderPage(currentPage + 1);
+      }
+    });
+
+    pageInput.addEventListener("change", () => {
+      renderPage(pageInput.value);
+    });
+
+    window.addEventListener("message", (event) => {
+      if (!event || typeof event.data !== "object" || event.data === null) {
+        return;
+      }
+      if (event.data.type === "setPage") {
+        renderPage(event.data.page);
+      }
+      if (event.data.type === "setDocument") {
+        const nextPdfUrl = String(event.data.pdfUrl || "");
+        const nextPage = Number(event.data.page) || 1;
+        if (!nextPdfUrl) {
+          return;
+        }
+        if (nextPdfUrl === pdfUrl) {
+          renderPage(nextPage);
+          return;
+        }
+        location.href = `${nextPdfUrl}#page=${nextPage}`;
+      }
+    });
+
+    const hashMatch = window.location.hash.match(/^#page=(\d+)$/);
+    if (hashMatch) {
+      currentPage = Number(hashMatch[1]);
+    }
+
+    loadPdf(currentPage).catch((err) => {
+      pageInfo.textContent = "Falling back to native PDF viewer";
+      console.error(err);
+      fallbackToNativePdf(currentPage);
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
This pull request adds a dedicated PDF.js-based viewer to the annotation UI, improving the PDF viewing and navigation experience. The main changes include introducing a new `pdf_viewer.html` template, updating the backend to serve this viewer, and modifying the frontend logic to use the new viewer and enable dynamic page switching without full reloads.

**Backend enhancements for PDF viewing:**

* Added a new Flask route `/pdfjs/<page_id>` in `annotation_ui.py` to serve a custom PDF.js viewer, rendering the new `pdf_viewer.html` template and passing the correct PDF source and initial page.
* Refactored PDF source resolution logic into a helper function `_resolve_source_pdf` for reuse and maintainability.

**Frontend integration with PDF.js viewer:**

* Updated `annotation_ui.js` so that the PDF iframe now loads the `/pdfjs/<page_id>` route instead of the raw PDF, and uses `postMessage` to instruct the viewer to switch pages without reloading the entire document.

**New PDF.js viewer UI:**

* Added `pdf_viewer.html`, a new template implementing a minimal PDF.js-based viewer with a toolbar for page navigation, keyboard input, and message-based communication for dynamic page switching.

**Minor dependency update:**

* Imported `url_for` from Flask in `annotation_ui.py` to generate URLs for the PDF endpoint.