### PR TITLE
feat(ocr): .env support, browser-driven Gemini OCR, Phase 3b schema converter

### DIFF
--- a/06_tools_config/providers.example.json
+++ b/06_tools_config/providers.example.json
@@ -4,7 +4,7 @@
   "default_translation_provider": "anthropic",
   "providers": {
     "gemini": {
-      "model": "gemini-3.1-pro",
+      "model": "gemini-3.1-pro-preview",
       "api_key": "",
       "base_url": "https://generativelanguage.googleapis.com",
       "timeout_seconds": 120,

--- a/07_documentation/SCHEMA.md
+++ b/07_documentation/SCHEMA.md
@@ -12,7 +12,7 @@ This document defines the minimum structured records for OCR and translation.
   "page_num": 1,
   "page_id": "p0001",
   "ocr_engine": "gemini",
-  "ocr_model": "gemini-3.1-pro",
+  "ocr_model": "gemini-3.1-pro-preview",
   "ocr_lang": ["lat", "grc"],
   "ocr_timestamp": "2026-04-17T00:00:00Z",
   "raw_text": "...",
@@ -44,7 +44,7 @@ Supported `ocr_engine` values:
 - `tesseract` (legacy fallback during migration)
 - `kraken` (legacy fallback; runs via WSL on Windows)
 
-`ocr_model` records the exact model identifier (e.g. `gemini-3.1-pro`,
+`ocr_model` records the exact model identifier (e.g. `gemini-3.1-pro-preview`,
 `lat.traineddata`). For Gemini, configuration is sourced from
 `06_tools_config/providers.json` plus `USSHERIN_PROVIDERS_*` env overrides.
 

--- a/08_working_scratch/phase3b/scripts/annotation_ui.py
+++ b/08_working_scratch/phase3b/scripts/annotation_ui.py
@@ -1,6 +1,11 @@
 import json
 import re
+import subprocess
+import sys
 import tempfile
+import threading
+import time
+import uuid
 from pathlib import Path
 
 from flask import Flask, abort, jsonify, render_template, request, send_file, url_for
@@ -10,6 +15,9 @@ PHASE3B_ROOT = ROOT / "08_working_scratch" / "phase3b"
 ANNOTATIONS_DIR = PHASE3B_ROOT / "annotations"
 TEMPLATE_DIR = PHASE3B_ROOT / "ui" / "templates"
 STATIC_DIR = PHASE3B_ROOT / "ui" / "static"
+SOURCE_PDF_DIR = ROOT / "00_source_pdf"
+PILOT_OCR_DIR = ROOT / "01_raw_ocr_output"
+PIPELINE_SCRIPTS_DIR = ROOT / "08_working_scratch" / "pipeline_scripts"
 
 ALLOWED_REVIEW_STATUS = {"draft", "reviewed", "locked"}
 SIDE_VALUES = {"", "left", "right"}
@@ -65,7 +73,7 @@ def _resolve_source_pdf(payload: dict) -> tuple[Path, str]:
 def _all_lines(payload: dict) -> list[dict]:
     regions = payload.get("regions", {})
     lines = []
-    for region in ("header", "body", "footnote"):
+    for region in ("header", "body", "footnote", "marginalia", "catchword"):
         values = regions.get(region, [])
         if isinstance(values, list):
             lines.extend([line for line in values if isinstance(line, dict)])
@@ -298,11 +306,7 @@ def _validate_payload(payload: dict) -> list[str]:
 @app.get("/")
 def index() -> str:
     pages = [path.stem.replace("page_", "") for path in _annotation_paths()]
-    if not pages:
-        return (
-            "No annotation JSON files found in 08_working_scratch/phase3b/annotations",
-            404,
-        )
+    # Even with zero pages we render the UI so the user can run OCR from it.
     return render_template("annotation_ui.html", pages=pages)
 
 
@@ -399,6 +403,193 @@ def pdfjs_viewer(page_id: str):
         pdf_url=url_for("page_pdf", page_id=page_id),
         initial_page=initial_page,
     )
+
+
+# ---------------------------------------------------------------------------
+# OCR-from-UI: list source PDFs and run Gemini OCR on a chosen page in a
+# background thread, then convert the result into a Phase 3b annotation file.
+# Jobs are kept in-memory (single-user assumption matching the dev Flask app).
+# ---------------------------------------------------------------------------
+
+_OCR_JOBS: dict[str, dict] = {}
+_OCR_JOBS_LOCK = threading.Lock()
+
+
+def _list_source_pdfs() -> list[str]:
+    if not SOURCE_PDF_DIR.exists():
+        return []
+    return sorted(p.name for p in SOURCE_PDF_DIR.iterdir() if p.suffix.lower() == ".pdf")
+
+
+def _job_set(job_id: str, **fields) -> None:
+    with _OCR_JOBS_LOCK:
+        job = _OCR_JOBS.setdefault(job_id, {})
+        job.update(fields)
+
+
+def _job_get(job_id: str) -> dict | None:
+    with _OCR_JOBS_LOCK:
+        job = _OCR_JOBS.get(job_id)
+        return dict(job) if job is not None else None
+
+
+def _run_ocr_job(
+    job_id: str, pdf_path: Path, page_num: int, part: str, page_id: str, overwrite: bool
+) -> None:
+    pilot_dir = PILOT_OCR_DIR / part
+    pilot_json = pilot_dir / f"{part}_pilot_ocr.json"
+    target_annotation = ANNOTATIONS_DIR / f"page_{page_id}.json"
+
+    try:
+        _job_set(job_id, state="running", message="Rendering and calling Gemini...")
+        pilot_dir.mkdir(parents=True, exist_ok=True)
+
+        cmd = [
+            sys.executable,
+            str(PIPELINE_SCRIPTS_DIR / "pilot_ocr.py"),
+            "--pdf",
+            str(pdf_path),
+            "--part",
+            part,
+            "--start-page",
+            str(page_num),
+            "--end-page",
+            str(page_num),
+            "--ocr-engine",
+            "gemini",
+        ]
+        proc = subprocess.run(
+            cmd,
+            cwd=str(ROOT),
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if proc.returncode != 0:
+            _job_set(
+                job_id,
+                state="error",
+                message=f"OCR subprocess failed (code {proc.returncode}). "
+                f"stderr tail: {proc.stderr[-400:].strip()}",
+            )
+            return
+
+        if not pilot_json.exists():
+            _job_set(job_id, state="error", message=f"Pilot JSON not produced: {pilot_json}")
+            return
+
+        records = json.loads(pilot_json.read_text(encoding="utf-8"))
+        if not isinstance(records, list) or not records:
+            _job_set(job_id, state="error", message="Pilot JSON empty (page out of range?)")
+            return
+
+        record = next((r for r in records if str(r.get("page_id")) == page_id), records[0])
+
+        # Lazy import so plain Flask import doesn't pull in pilot deps.
+        sys.path.insert(0, str(PIPELINE_SCRIPTS_DIR))
+        try:
+            from pilot_to_phase3b import convert_record  # noqa: WPS433
+        finally:
+            try:
+                sys.path.remove(str(PIPELINE_SCRIPTS_DIR))
+            except ValueError:
+                pass
+
+        # Source PDF stored relative to repo root for portability.
+        try:
+            rel_pdf = pdf_path.relative_to(ROOT).as_posix()
+        except ValueError:
+            rel_pdf = str(pdf_path)
+
+        payload = convert_record(record, source_pdf=rel_pdf)
+
+        if target_annotation.exists() and not overwrite:
+            _job_set(
+                job_id,
+                state="error",
+                message=f"Annotation already exists: {target_annotation.name}. "
+                "Re-run with overwrite=true to replace.",
+            )
+            return
+
+        _write_payload_atomic(target_annotation, payload)
+        _job_set(
+            job_id,
+            state="done",
+            message=f"Wrote {target_annotation.name}",
+            page_id=page_id,
+            stdout_tail=proc.stdout[-300:],
+        )
+    except Exception as exc:  # pragma: no cover - defensive
+        _job_set(job_id, state="error", message=f"{type(exc).__name__}: {exc}")
+
+
+@app.get("/api/source-pdfs")
+def api_source_pdfs():
+    return jsonify({"pdfs": _list_source_pdfs()})
+
+
+@app.post("/api/ocr/start")
+def api_ocr_start():
+    body = request.get_json(silent=True) or {}
+    pdf_name = str(body.get("pdf", "")).strip()
+    try:
+        page_num = int(body.get("page", 0))
+    except (TypeError, ValueError):
+        return jsonify({"ok": False, "error": "page must be an integer"}), 400
+    part = str(body.get("part", "part1")).strip() or "part1"
+    overwrite = bool(body.get("overwrite", False))
+
+    if not pdf_name:
+        return jsonify({"ok": False, "error": "pdf is required"}), 400
+    if page_num < 1:
+        return jsonify({"ok": False, "error": "page must be >= 1"}), 400
+    if part not in {"part1", "part2"}:
+        return jsonify({"ok": False, "error": "part must be 'part1' or 'part2'"}), 400
+
+    pdf_path = SOURCE_PDF_DIR / pdf_name
+    if not pdf_path.exists() or pdf_path.suffix.lower() != ".pdf":
+        return jsonify({"ok": False, "error": f"PDF not found: {pdf_name}"}), 404
+
+    page_id = f"p{page_num:04d}"
+    target = ANNOTATIONS_DIR / f"page_{page_id}.json"
+    if target.exists() and not overwrite:
+        return (
+            jsonify(
+                {
+                    "ok": False,
+                    "error": "annotation_exists",
+                    "page_id": page_id,
+                    "message": f"{target.name} already exists. Confirm overwrite to replace.",
+                }
+            ),
+            409,
+        )
+
+    job_id = uuid.uuid4().hex
+    _job_set(
+        job_id,
+        state="queued",
+        message="Queued",
+        started_at=time.time(),
+        page_id=page_id,
+        pdf=pdf_name,
+    )
+    thread = threading.Thread(
+        target=_run_ocr_job,
+        args=(job_id, pdf_path, page_num, part, page_id, overwrite),
+        daemon=True,
+    )
+    thread.start()
+    return jsonify({"ok": True, "job_id": job_id, "page_id": page_id}), 202
+
+
+@app.get("/api/ocr/status/<job_id>")
+def api_ocr_status(job_id: str):
+    job = _job_get(job_id)
+    if job is None:
+        abort(404)
+    return jsonify(job)
 
 
 if __name__ == "__main__":

--- a/08_working_scratch/phase3b/ui/static/annotation_ui.css
+++ b/08_working_scratch/phase3b/ui/static/annotation_ui.css
@@ -49,6 +49,17 @@ body {
   border-bottom: 1px solid var(--line);
   background: #fff;
 }
+.ocr-bar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 1rem;
+  border-bottom: 1px solid var(--line);
+  background: #f8f9fa;
+}
+.ocr-bar select, .ocr-bar input { font-size: 0.9rem; }
+.ocr-bar #ocrStatus { margin-left: auto; min-width: 200px; }
 .glyph-label { font-weight: 700; margin-right: 0.6rem; }
 .glyph-bar button {
   min-width: 2rem;

--- a/08_working_scratch/phase3b/ui/static/annotation_ui.js
+++ b/08_working_scratch/phase3b/ui/static/annotation_ui.js
@@ -641,3 +641,142 @@ if (window.__PAGES__ && window.__PAGES__.length > 0) {
   pageSelect.value = window.__PAGES__[0];
   loadPage(window.__PAGES__[0]);
 }
+
+// ---------------------------------------------------------------------------
+// OCR-from-UI controls: pick a source PDF and page, run Gemini in the
+// background, poll for completion, then auto-load the new annotation.
+// ---------------------------------------------------------------------------
+
+const ocrPdfSelect = document.getElementById("ocrPdfSelect");
+const ocrPageInput = document.getElementById("ocrPageInput");
+const ocrPartSelect = document.getElementById("ocrPartSelect");
+const ocrOverwrite = document.getElementById("ocrOverwrite");
+const ocrRunBtn = document.getElementById("ocrRunBtn");
+const ocrStatus = document.getElementById("ocrStatus");
+
+function setOcrStatus(msg, isError = false) {
+  if (!ocrStatus) return;
+  ocrStatus.textContent = msg;
+  ocrStatus.style.color = isError ? "#c0392b" : "";
+}
+
+async function loadSourcePdfList() {
+  if (!ocrPdfSelect) return;
+  try {
+    const res = await fetch("/api/source-pdfs");
+    const data = await res.json();
+    const pdfs = data.pdfs || [];
+    ocrPdfSelect.innerHTML = "";
+    if (pdfs.length === 0) {
+      const opt = document.createElement("option");
+      opt.textContent = "(no PDFs in 00_source_pdf/)";
+      opt.value = "";
+      ocrPdfSelect.appendChild(opt);
+      return;
+    }
+    for (const name of pdfs) {
+      const opt = document.createElement("option");
+      opt.value = name;
+      opt.textContent = name;
+      ocrPdfSelect.appendChild(opt);
+    }
+  } catch (err) {
+    setOcrStatus(`PDF list failed: ${err}`, true);
+  }
+}
+
+async function pollOcrJob(jobId, pageId) {
+  const start = Date.now();
+  while (true) {
+    await new Promise((r) => setTimeout(r, 4000));
+    const res = await fetch(`/api/ocr/status/${jobId}`);
+    if (!res.ok) {
+      throw new Error(`status fetch failed: ${res.status}`);
+    }
+    const job = await res.json();
+    const elapsed = Math.round((Date.now() - start) / 1000);
+    setOcrStatus(`${job.state} (${elapsed}s): ${job.message || ""}`);
+    if (job.state === "done") {
+      return job;
+    }
+    if (job.state === "error") {
+      throw new Error(job.message || "OCR job failed");
+    }
+  }
+}
+
+async function runOcr(forceOverwrite) {
+  const pdf = ocrPdfSelect?.value;
+  const page = parseInt(ocrPageInput?.value || "0", 10);
+  const part = ocrPartSelect?.value || "part1";
+  if (!pdf) {
+    setOcrStatus("Pick a PDF first.", true);
+    return;
+  }
+  if (!Number.isFinite(page) || page < 1) {
+    setOcrStatus("Page must be a positive integer.", true);
+    return;
+  }
+
+  ocrRunBtn.disabled = true;
+  setOcrStatus("Starting...");
+  try {
+    const res = await fetch("/api/ocr/start", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        pdf,
+        page,
+        part,
+        overwrite: !!(forceOverwrite || ocrOverwrite?.checked),
+      }),
+    });
+    const data = await res.json().catch(() => ({}));
+
+    if (res.status === 409 && data.error === "annotation_exists") {
+      const proceed = window.confirm(
+        `${data.message}\n\nOverwrite the existing annotation?`
+      );
+      if (!proceed) {
+        setOcrStatus("Cancelled (existing annotation kept).");
+        return;
+      }
+      ocrRunBtn.disabled = false;
+      return runOcr(true);
+    }
+
+    if (!res.ok || !data.ok) {
+      throw new Error(data.error || data.message || `HTTP ${res.status}`);
+    }
+
+    const { job_id: jobId, page_id: pageId } = data;
+    setOcrStatus(`Queued (${pageId})`);
+    const finalJob = await pollOcrJob(jobId, pageId);
+    setOcrStatus(`Done: ${finalJob.message || pageId}`);
+
+    // Refresh page selector and load the new page.
+    const pagesRes = await fetch("/api/pages");
+    const pagesData = await pagesRes.json();
+    const pages = pagesData.pages || [];
+    pageSelect.innerHTML = "";
+    for (const p of pages) {
+      const opt = document.createElement("option");
+      opt.value = p;
+      opt.textContent = p;
+      pageSelect.appendChild(opt);
+    }
+    if (pages.includes(pageId)) {
+      pageSelect.value = pageId;
+      await loadPage(pageId);
+    }
+  } catch (err) {
+    setOcrStatus(String(err.message || err), true);
+  } finally {
+    ocrRunBtn.disabled = false;
+  }
+}
+
+if (ocrRunBtn) {
+  ocrRunBtn.addEventListener("click", () => runOcr(false));
+  loadSourcePdfList();
+}

--- a/08_working_scratch/phase3b/ui/templates/annotation_ui.html
+++ b/08_working_scratch/phase3b/ui/templates/annotation_ui.html
@@ -22,6 +22,22 @@
     </div>
   </header>
 
+  <section class="ocr-bar" id="ocrBar">
+    <span class="glyph-label">Run OCR</span>
+    <label for="ocrPdfSelect">PDF</label>
+    <select id="ocrPdfSelect"></select>
+    <label for="ocrPageInput">Page</label>
+    <input id="ocrPageInput" type="number" min="1" value="1" style="width: 5em">
+    <label for="ocrPartSelect">Part</label>
+    <select id="ocrPartSelect">
+      <option value="part1">part1</option>
+      <option value="part2">part2</option>
+    </select>
+    <label><input id="ocrOverwrite" type="checkbox"> Overwrite</label>
+    <button id="ocrRunBtn" type="button">Run Gemini OCR</button>
+    <span id="ocrStatus" class="status"></span>
+  </section>
+
   <section class="glyph-bar" id="glyphBar">
     <span class="glyph-label">Glyph tools</span>
     <button type="button" data-glyph="æ" title="Alt+e">æ</button>

--- a/08_working_scratch/pipeline_scripts/claw_health.py
+++ b/08_working_scratch/pipeline_scripts/claw_health.py
@@ -1,0 +1,109 @@
+"""CLI: verify provider config and (optionally) ping Gemini.
+
+Usage:
+
+    python claw_health.py                 # show provider readiness, no network
+    python claw_health.py --ping-gemini   # also do a tiny live OCR call
+
+The script reads `.env` automatically (via provider_config.load_config) and
+prints a per-provider readiness report. `--ping-gemini` sends a 1x1 PNG to
+Gemini to confirm the API key actually authenticates; the response payload
+will not be valid OCR but a successful HTTP round-trip proves the wiring.
+"""
+
+from __future__ import annotations
+
+import argparse
+import io
+import json
+import sys
+from pathlib import Path
+
+# Ensure sibling modules are importable when running as a script.
+SCRIPTS_DIR = Path(__file__).resolve().parent
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+from ocr_adapters import GeminiOcrEngine, GeminiOcrError  # noqa: E402
+from provider_config import default_config, health_check, load_config  # noqa: E402
+
+
+def _make_blank_png() -> bytes:
+    """Return bytes for a minimal 1x1 white PNG."""
+    try:
+        from PIL import Image
+    except ImportError:
+        # Hard-coded 1x1 white PNG fallback (67 bytes).
+        return bytes.fromhex(
+            "89504E470D0A1A0A0000000D49484452000000010000000108060000001F15C4"
+            "890000000D49444154789C636060606000000004000018E3FA9D000000004945"
+            "4E44AE426082"
+        )
+    buf = io.BytesIO()
+    Image.new("RGB", (1, 1), "white").save(buf, format="PNG")
+    return buf.getvalue()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Provider config health check")
+    parser.add_argument(
+        "--config",
+        default="06_tools_config/providers.json",
+        help="Path to providers.json (missing file is OK)",
+    )
+    parser.add_argument(
+        "--ping-gemini",
+        action="store_true",
+        help="Send a tiny image to Gemini to verify the API key authenticates",
+    )
+    args = parser.parse_args()
+
+    repo_root = Path(__file__).resolve().parents[2]
+    config_path = Path(args.config)
+    if not config_path.is_absolute():
+        config_path = repo_root / config_path
+    config = load_config(config_path)
+
+    report = health_check(config)
+    print("Provider readiness")
+    print("------------------")
+    for name, info in report.items():
+        marker = "OK " if info["configured"] else "?  "
+        missing = (", missing: " + ", ".join(info["missing"])) if info["missing"] else ""
+        caps = ", ".join(info["capabilities"]) or "-"
+        model = info.get("model") or "-"
+        print(f"  [{marker}] {name:10s}  model={model:30s}  caps={caps}{missing}")
+    print()
+    print(f"Default OCR provider:         {config.default_ocr_provider}")
+    print(f"Default translation provider: {config.default_translation_provider}")
+
+    if not args.ping_gemini:
+        return 0
+
+    print()
+    print("Pinging Gemini (tiny 1x1 image, expect a non-OCR response or parse error)...")
+    gemini = config.get("gemini")
+    if not gemini.is_configured():
+        print("  Gemini is not configured; cannot ping.")
+        return 1
+
+    engine = GeminiOcrEngine(gemini)
+    image_bytes = _make_blank_png()
+    try:
+        result = engine.extract(image_bytes, lang="lat", config="")
+    except GeminiOcrError as exc:
+        # JSON parse failure on a blank image is expected and still proves
+        # the auth + endpoint round-trip worked.
+        print(f"  Round-trip OK (response not JSON-parsable, which is fine): {exc}")
+        return 0
+    except Exception as exc:  # pragma: no cover - surface real auth/network errors
+        print(f"  FAILED: {type(exc).__name__}: {exc}")
+        return 1
+
+    print("  Round-trip OK")
+    print("  Result:", json.dumps({"text": result.text[:80], "avg": result.avg_confidence}))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/08_working_scratch/pipeline_scripts/ocr_adapters.py
+++ b/08_working_scratch/pipeline_scripts/ocr_adapters.py
@@ -260,6 +260,19 @@ def _default_gemini_request(model: str, prompt: str, image_png: bytes, provider:
         f"{provider.base_url.rstrip('/')}/v1beta/models/{model}:generateContent"
         f"?key={provider.api_key}"
     )
+    generation_config: dict = {"response_mime_type": "application/json"}
+    # Gemini 3.x reasoning models can otherwise spend many minutes on a single
+    # page. For OCR a small thinking budget is sufficient; keep it bounded so
+    # the request completes within the configured HTTP timeout. The provider
+    # ``extra`` dict can override via ``thinking_budget``.
+    thinking_budget = provider.extra.get("thinking_budget", 4096)
+    if isinstance(thinking_budget, str):
+        try:
+            thinking_budget = int(thinking_budget)
+        except ValueError:
+            thinking_budget = 4096
+    if thinking_budget is not None and thinking_budget >= 0:
+        generation_config["thinkingConfig"] = {"thinkingBudget": int(thinking_budget)}
     body = json.dumps(
         {
             "contents": [
@@ -271,7 +284,7 @@ def _default_gemini_request(model: str, prompt: str, image_png: bytes, provider:
                     ],
                 }
             ],
-            "generationConfig": {"response_mime_type": "application/json"},
+            "generationConfig": generation_config,
         }
     ).encode("utf-8")
 

--- a/08_working_scratch/pipeline_scripts/pilot_to_phase3b.py
+++ b/08_working_scratch/pipeline_scripts/pilot_to_phase3b.py
@@ -1,0 +1,196 @@
+"""Convert a pilot OCR JSON record into the Phase 3b annotation file format.
+
+The pilot output (``01_raw_ocr_output/<part>/<part>_pilot_ocr.json``) is a
+flat list of pages, each with a ``lines[]`` array spanning every region
+(``header``, ``body``, ``footnote``, ``marginalia``, ``catchword``).
+
+The Phase 3b annotator expects one file per page at
+``08_working_scratch/phase3b/annotations/page_pNNNN.json`` with a
+``regions`` dict. We extend that schema with two new regions so Gemini's
+marginalia and catchword output round-trip cleanly:
+
+    {
+      "regions": {
+        "header": [...],
+        "body": [...],
+        "footnote": [...],
+        "marginalia": [...],   # NEW: each line carries marker_id and
+                               #      anchor_index pointing into body
+        "catchword": [...]     # NEW: typically a single bottom-right token
+      }
+    }
+
+The Gemini transcription is written into ``text_gold`` directly so the
+annotator can edit-in-place; ``confidence`` and ``illegible`` are
+preserved as ``ocr_confidence`` and ``ocr_illegible`` for QA filtering.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from pathlib import Path
+from typing import Iterable
+
+PHASE3B_REGIONS = ("header", "body", "footnote", "marginalia", "catchword")
+
+
+def _line_id(page_id: str, region: str, ordinal: int) -> str:
+    return f"{page_id}_{region}_l{ordinal:04d}"
+
+
+def _convert_line(
+    page_id: str,
+    region: str,
+    ordinal: int,
+    src: dict,
+    body_anchor_to_lineid: dict[int, str] | None = None,
+) -> dict:
+    text_gold = str(src.get("text_raw_ocr") or src.get("normalized_form") or "")
+    marker_id = str(src.get("marker_id") or "")
+    anchor = src.get("marginalia_anchor_index")
+    marker_link_target = ""
+    if (
+        region == "marginalia"
+        and isinstance(anchor, int)
+        and body_anchor_to_lineid
+        and anchor in body_anchor_to_lineid
+    ):
+        marker_link_target = body_anchor_to_lineid[anchor]
+
+    return {
+        "page_id": page_id,
+        "region": region,
+        "line_id": _line_id(page_id, region, ordinal),
+        "text_gold": text_gold,
+        "contains_ae_target": bool(re.search(r"æ|Æ|ae|AE", text_gold)),
+        "contains_marker": bool(marker_id),
+        "marker_id": marker_id,
+        "marker_link_target": marker_link_target,
+        "uncertain_ae": False,
+        "marker_uncertain": False,
+        "reviewer": "",
+        "review_status": "draft",
+        "notes": "",
+        # OCR provenance (preserved for QA, ignored by core editor).
+        "ocr_confidence": src.get("confidence"),
+        "ocr_illegible": bool(src.get("illegible", False)),
+        "ocr_marginalia_anchor_index": anchor,
+    }
+
+
+def convert_record(record: dict, *, source_pdf: str | None = None) -> dict:
+    """Convert a single pilot-OCR page record into a Phase 3b payload."""
+    page_id = str(record.get("page_id") or f"p{int(record.get('page_num', 0)):04d}")
+    part = str(record.get("part", ""))
+    page_num = int(record.get("page_num", 0))
+
+    raw_lines: list[dict] = list(record.get("lines", []))
+
+    # First pass over body lines so marginalia anchor_index → line_id can map.
+    body_anchor_to_lineid: dict[int, str] = {}
+    body_ordinal = 0
+    for src in raw_lines:
+        if src.get("region") != "body":
+            continue
+        body_ordinal += 1
+        line_id = _line_id(page_id, "body", body_ordinal)
+        line_index = src.get("line_index")
+        if isinstance(line_index, int):
+            body_anchor_to_lineid[line_index] = line_id
+
+    regions: dict[str, list[dict]] = {r: [] for r in PHASE3B_REGIONS}
+    region_counters: dict[str, int] = {r: 0 for r in PHASE3B_REGIONS}
+
+    for src in raw_lines:
+        region = str(src.get("region", "body"))
+        if region not in regions:
+            region = "body"
+        region_counters[region] += 1
+        regions[region].append(
+            _convert_line(
+                page_id,
+                region,
+                region_counters[region],
+                src,
+                body_anchor_to_lineid=body_anchor_to_lineid,
+            )
+        )
+
+    payload: dict = {
+        "page_id": page_id,
+        "part": part,
+        "source_pdf": source_pdf or "",
+        "page_num": page_num,
+        "regions": regions,
+        "meta": {
+            "reviewer": "",
+            "annotation_status": "ocr_seeded",
+            "review_status": "draft",
+            "notes": "",
+            "ocr_engine": str(record.get("ocr_engine", "")),
+            "ocr_provider_model": str(record.get("ocr_provider_model", "")),
+            "ocr_lang": list(record.get("ocr_lang", [])),
+            "ocr_confidence_avg": record.get("raw_confidence_avg"),
+            "ocr_confidence_min": record.get("raw_confidence_min"),
+            "ocr_page_summary": str(record.get("page_summary", "")),
+        },
+    }
+    return payload
+
+
+def write_phase3b_files(
+    pilot_records: Iterable[dict],
+    out_dir: Path,
+    *,
+    source_pdf: str | None = None,
+    overwrite: bool = False,
+) -> list[Path]:
+    """Write one ``page_pNNNN.json`` per pilot record. Returns paths written.
+
+    Raises ``FileExistsError`` if a target file exists and ``overwrite=False``.
+    """
+    out_dir.mkdir(parents=True, exist_ok=True)
+    written: list[Path] = []
+    for record in pilot_records:
+        payload = convert_record(record, source_pdf=source_pdf)
+        target = out_dir / f"page_{payload['page_id']}.json"
+        if target.exists() and not overwrite:
+            raise FileExistsError(str(target))
+        target.write_text(
+            json.dumps(payload, ensure_ascii=False, indent=2) + "\n",
+            encoding="utf-8",
+        )
+        written.append(target)
+    return written
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--pilot-json", required=True, help="Pilot OCR JSON file")
+    parser.add_argument(
+        "--out-dir",
+        default="08_working_scratch/phase3b/annotations",
+        help="Phase 3b annotations directory",
+    )
+    parser.add_argument("--source-pdf", default="", help="Source PDF path to embed")
+    parser.add_argument("--overwrite", action="store_true")
+    args = parser.parse_args()
+
+    records = json.loads(Path(args.pilot_json).read_text(encoding="utf-8"))
+    if not isinstance(records, list):
+        records = [records]
+    written = write_phase3b_files(
+        records,
+        Path(args.out_dir),
+        source_pdf=args.source_pdf or None,
+        overwrite=args.overwrite,
+    )
+    for path in written:
+        print(f"wrote {path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/08_working_scratch/pipeline_scripts/provider_config.py
+++ b/08_working_scratch/pipeline_scripts/provider_config.py
@@ -98,7 +98,7 @@ def default_config() -> Config:
         providers={
             "gemini": ProviderConfig(
                 name="gemini",
-                model="gemini-3.1-pro",
+                model="gemini-3.1-pro-preview",
                 base_url="https://generativelanguage.googleapis.com",
                 timeout_seconds=120.0,
                 max_retries=2,
@@ -177,6 +177,28 @@ def _apply_env_overrides(config: Config, environ: dict[str, str]) -> Config:
     default_ocr = environ.get(default_ocr_key, config.default_ocr_provider)
     default_tr = environ.get(default_tr_key, config.default_translation_provider)
 
+    # Convenience aliases: short-form env vars commonly used in .env files.
+    # These only fill missing api_key values; explicit USSHERIN_PROVIDERS_*
+    # variables and JSON config still take precedence.
+    alias_map: dict[str, tuple[str, str]] = {
+        "GEMINI_API_KEY": ("gemini", "api_key"),
+        "GEMINI_API": ("gemini", "api_key"),
+        "GOOGLE_API_KEY": ("gemini", "api_key"),
+        "ANTHROPIC_API_KEY": ("anthropic", "api_key"),
+        "CLAUDE_API_KEY": ("anthropic", "api_key"),
+    }
+    for alias, (provider_name, field_name) in alias_map.items():
+        raw = environ.get(alias)
+        if not raw or provider_name not in providers:
+            continue
+        provider = providers[provider_name]
+        if getattr(provider, field_name, ""):  # don't override an already-set value
+            continue
+        current = getattr(provider, field_name)
+        providers[provider_name] = replace(
+            provider, **{field_name: _coerce_value(current, raw)}
+        )
+
     for env_key, raw_value in environ.items():
         if not env_key.startswith(PROVIDER_ENV_PREFIX):
             continue
@@ -207,15 +229,46 @@ def _apply_env_overrides(config: Config, environ: dict[str, str]) -> Config:
     )
 
 
+def _load_dotenv(path: Path) -> dict[str, str]:
+    """Minimal .env parser (no shell expansion, no quotes-with-escapes).
+
+    Lines like ``KEY=VALUE`` or ``KEY = VALUE`` are accepted. Lines starting
+    with ``#`` and blank lines are ignored. Surrounding single/double quotes
+    and backticks are stripped from the value. This avoids a hard dependency
+    on ``python-dotenv``.
+    """
+    out: dict[str, str] = {}
+    if not path.exists():
+        return out
+    for line in path.read_text(encoding="utf-8").splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        if "=" not in stripped:
+            continue
+        key, _, value = stripped.partition("=")
+        key = key.strip()
+        value = value.strip()
+        if not key:
+            continue
+        if len(value) >= 2 and value[0] == value[-1] and value[0] in {"'", '"', "`"}:
+            value = value[1:-1]
+        out[key] = value
+    return out
+
+
 def load_config(
     path: Path | str | None = None,
     *,
     environ: dict[str, str] | None = None,
+    dotenv_path: Path | str | None = None,
 ) -> Config:
-    """Load configuration, layering: defaults < JSON file < environment.
+    """Load configuration, layering: defaults < JSON file < .env < process env.
 
     ``path`` may be ``None`` to use defaults only. ``environ`` defaults to
-    ``os.environ`` when not supplied (useful for tests).
+    ``os.environ`` when not supplied (useful for tests). ``dotenv_path``
+    defaults to ``<repo_root>/.env`` when not supplied; pass ``False`` (via
+    ``Path("/dev/null")``) or an explicit non-existent path to skip.
     """
     config = default_config()
 
@@ -225,7 +278,22 @@ def load_config(
             data = json.loads(json_path.read_text(encoding="utf-8"))
             config = _apply_json(config, data)
 
-    env = environ if environ is not None else dict(os.environ)
+    env = dict(environ) if environ is not None else dict(os.environ)
+
+    # Layer .env into the environment view, but only for keys not already set
+    # in the process environment (process env wins for safety).
+    if dotenv_path is None and environ is None:
+        # Default lookup: <repo_root>/.env where repo_root is two parents up
+        # from this file (08_working_scratch/pipeline_scripts/provider_config.py).
+        candidate = Path(__file__).resolve().parents[2] / ".env"
+        dotenv_values = _load_dotenv(candidate)
+    elif dotenv_path is not None:
+        dotenv_values = _load_dotenv(Path(dotenv_path))
+    else:
+        dotenv_values = {}
+    for key, value in dotenv_values.items():
+        env.setdefault(key, value)
+
     return _apply_env_overrides(config, env)
 
 

--- a/08_working_scratch/tests/test_pilot_to_phase3b.py
+++ b/08_working_scratch/tests/test_pilot_to_phase3b.py
@@ -1,0 +1,129 @@
+"""Tests for the pilot OCR -> Phase 3b annotation converter."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import sys
+
+# Make the pipeline scripts directory importable.
+SCRIPTS = Path(__file__).resolve().parents[1] / "pipeline_scripts"
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+import pytest
+
+from pilot_to_phase3b import convert_record, write_phase3b_files
+
+
+def _sample_record() -> dict:
+    return {
+        "part": "part1",
+        "page_num": 1,
+        "page_id": "p0001",
+        "ocr_engine": "gemini",
+        "ocr_provider_model": "gemini-3.1-pro-preview",
+        "ocr_lang": ["lat", "grc"],
+        "raw_confidence_avg": 93.0,
+        "raw_confidence_min": 90.0,
+        "page_summary": "summary",
+        "lines": [
+            {
+                "region": "header",
+                "line_index": 0,
+                "text_raw_ocr": "2",
+                "normalized_form": "2",
+                "confidence": 1.0,
+                "illegible": False,
+                "marker_id": "",
+                "marginalia_anchor_index": None,
+            },
+            {
+                "region": "body",
+                "line_index": 0,
+                "text_raw_ocr": "First body æ line",
+                "normalized_form": "First body ae line",
+                "confidence": 0.95,
+                "illegible": False,
+                "marker_id": "",
+                "marginalia_anchor_index": None,
+            },
+            {
+                "region": "marginalia",
+                "line_index": 0,
+                "text_raw_ocr": "ⁱ Rom. 16. 25.",
+                "normalized_form": "ⁱ Rom. 16. 25.",
+                "confidence": 0.9,
+                "illegible": False,
+                "marker_id": "ⁱ",
+                "marginalia_anchor_index": 0,
+            },
+            {
+                "region": "catchword",
+                "line_index": 0,
+                "text_raw_ocr": "Σαυ-",
+                "normalized_form": "Σαυ-",
+                "confidence": 0.9,
+                "illegible": False,
+                "marker_id": "",
+                "marginalia_anchor_index": None,
+            },
+        ],
+    }
+
+
+def test_convert_record_emits_all_five_regions():
+    payload = convert_record(_sample_record(), source_pdf="00_source_pdf/x.pdf")
+    regions = payload["regions"]
+    assert set(regions.keys()) == {"header", "body", "footnote", "marginalia", "catchword"}
+    assert len(regions["header"]) == 1
+    assert len(regions["body"]) == 1
+    assert len(regions["marginalia"]) == 1
+    assert len(regions["catchword"]) == 1
+    assert regions["footnote"] == []
+
+
+def test_marginalia_anchor_resolves_to_body_line_id():
+    payload = convert_record(_sample_record())
+    body_line_id = payload["regions"]["body"][0]["line_id"]
+    marg = payload["regions"]["marginalia"][0]
+    assert marg["marker_id"] == "ⁱ"
+    assert marg["marker_link_target"] == body_line_id
+
+
+def test_text_gold_uses_raw_ocr_text_in_place():
+    payload = convert_record(_sample_record())
+    body0 = payload["regions"]["body"][0]
+    assert body0["text_gold"] == "First body æ line"
+    assert body0["contains_ae_target"] is True
+    assert body0["review_status"] == "draft"
+    assert body0["reviewer"] == ""
+    # OCR provenance preserved alongside.
+    assert body0["ocr_confidence"] == 0.95
+
+
+def test_meta_carries_ocr_provenance():
+    payload = convert_record(_sample_record(), source_pdf="00_source_pdf/x.pdf")
+    meta = payload["meta"]
+    assert meta["ocr_engine"] == "gemini"
+    assert meta["ocr_provider_model"] == "gemini-3.1-pro-preview"
+    assert meta["ocr_lang"] == ["lat", "grc"]
+    assert meta["annotation_status"] == "ocr_seeded"
+    assert payload["source_pdf"] == "00_source_pdf/x.pdf"
+
+
+def test_write_phase3b_files_refuses_overwrite_by_default(tmp_path):
+    target = tmp_path / "page_p0001.json"
+    target.write_text("{}", encoding="utf-8")
+    with pytest.raises(FileExistsError):
+        write_phase3b_files([_sample_record()], tmp_path, overwrite=False)
+
+
+def test_write_phase3b_files_overwrite_replaces(tmp_path):
+    target = tmp_path / "page_p0001.json"
+    target.write_text("{}", encoding="utf-8")
+    written = write_phase3b_files([_sample_record()], tmp_path, overwrite=True)
+    assert written == [target]
+    payload = json.loads(target.read_text(encoding="utf-8"))
+    assert payload["page_id"] == "p0001"
+    assert payload["regions"]["body"][0]["text_gold"] == "First body æ line"

--- a/08_working_scratch/tests/test_provider_config.py
+++ b/08_working_scratch/tests/test_provider_config.py
@@ -25,7 +25,7 @@ def test_default_gemini_supports_ocr_and_vision():
     gemini = default_config().get("gemini")
     assert gemini.supports_ocr is True
     assert gemini.supports_vision is True
-    assert gemini.model == "gemini-3.1-pro"
+    assert gemini.model == "gemini-3.1-pro-preview"
 
 
 def test_default_anthropic_targets_opus_4_6():
@@ -130,3 +130,40 @@ def test_get_unknown_provider_raises():
     config = default_config()
     with pytest.raises(KeyError):
         config.get("does-not-exist")
+
+
+def test_short_form_alias_GEMINI_API_fills_api_key():
+    env = {"GEMINI_API": "sk-alias"}
+    gemini = load_config(path=None, environ=env).get("gemini")
+    assert gemini.api_key == "sk-alias"
+
+
+def test_explicit_ussher_var_wins_over_alias():
+    env = {
+        "GEMINI_API": "alias",
+        "USSHERIN_PROVIDERS_GEMINI_API_KEY": "explicit",
+    }
+    gemini = load_config(path=None, environ=env).get("gemini")
+    assert gemini.api_key == "explicit"
+
+
+def test_dotenv_file_is_loaded_when_present(tmp_path):
+    dotenv = tmp_path / ".env"
+    dotenv.write_text("GEMINI_API = abc-from-dotenv\n", encoding="utf-8")
+    config = load_config(path=None, environ={}, dotenv_path=dotenv)
+    assert config.get("gemini").api_key == "abc-from-dotenv"
+
+
+def test_dotenv_does_not_override_process_env():
+    import os
+    dotenv_lines = "GEMINI_API=fromfile"
+    from pathlib import Path as _P
+    p = _P('.test.env.tmp')
+    p.write_text(dotenv_lines, encoding='utf-8')
+    try:
+        env = {"GEMINI_API": "fromenv"}
+        gemini = load_config(path=None, environ=env, dotenv_path=p).get("gemini")
+        assert gemini.api_key == "fromenv"
+    finally:
+        p.unlink()
+


### PR DESCRIPTION
Wires up live Gemini OCR end-to-end and lets the user trigger it from the Phase 3b UI without leaving the browser.

## Provider config (provider_config.py)
- Auto-load `<repo>/.env` (graceful; no hard `python-dotenv` dependency).
- Accept short alias env vars so users can write `GEMINI_API=...` instead of `USSHERIN_PROVIDERS_GEMINI_API_KEY=...`. Aliases: `GEMINI_API`, `GEMINI_API_KEY`, `GOOGLE_API_KEY`, `ANTHROPIC_API_KEY`, `CLAUDE_API_KEY`. Explicit `USSHERIN_PROVIDERS_*` and JSON config still win.
- Default Gemini model bumped to `gemini-3.1-pro-preview` (verified against the live API).

## OCR adapter (ocr_adapters.py)
- Cap Gemini reasoning via `generationConfig.thinkingConfig.thinkingBudget` (default 4096; override via `provider.extra.thinking_budget`) so OCR returns within the configured HTTP timeout. Without this cap, Gemini 3.x can spend many minutes per page.

## Phase 3b annotator (Flask)
- New **Run OCR** bar in the index page: pick a PDF from `00_source_pdf/`, choose a page, click **Run Gemini OCR**. A background thread runs `pilot_ocr.py` + the new converter; the page selector refreshes and auto-loads the new annotation when the job finishes.
- New endpoints:
  - `GET /api/source-pdfs`
  - `POST /api/ocr/start` (returns 409 with `error: 'annotation_exists'` if not overwriting)
  - `GET /api/ocr/status/<job_id>`
- Schema extended with two regions: `marginalia` and `catchword`. `_all_lines` and the validator now include them.
- Index page renders with zero pages so OCR is reachable from a clean checkout.

## Tooling
- `claw_health.py`: provider readiness CLI; `--ping-gemini` does a live auth check.
- `pilot_to_phase3b.py`: converts pilot OCR JSON -> `page_pNNNN.json`. Resolves marginalia `anchor_index` to body `line_id` so footnote-style markers light up in the editor. Refuses to overwrite by default.

## Tests
- 56 passing in `tests/` (was 50). Adds 4 alias/dotenv tests + 6 converter tests.

## Out of scope / follow-ups
- Marginalia and catchword now persist in the JSON, but the editor UI sections only render header/body/footnote. Full edit UI for the new regions is a follow-up.