### PR TITLE
Phase 3b: redesign annotation UI for Gemini OCR

### DIFF
--- a/08_working_scratch/phase3b/scripts/annotation_ui.py
+++ b/08_working_scratch/phase3b/scripts/annotation_ui.py
@@ -1,3 +1,4 @@
+import datetime as _dt
 import json
 import re
 import subprocess
@@ -20,15 +21,8 @@ PILOT_OCR_DIR = ROOT / "01_raw_ocr_output"
 PIPELINE_SCRIPTS_DIR = ROOT / "08_working_scratch" / "pipeline_scripts"
 
 ALLOWED_REVIEW_STATUS = {"draft", "reviewed", "locked"}
-SIDE_VALUES = {"", "left", "right"}
-
-HEADER_OVERRIDE_FIELDS: dict[str, str] = {
-    "contains_header_page_number": "bool",
-    "contains_header_chapter_number": "bool",
-    "header_page_number_side": "side",
-    "header_chapter_side": "side",
-    "header_parity_consistent": "bool",
-}
+ALLOWED_FOOTNOTE_KIND = {"citation", "gloss", "cross_ref", "not_a_note", "other"}
+SCHEMA_REGIONS = ("header", "body", "marginalia", "catchword")
 
 app = Flask(__name__, template_folder=str(TEMPLATE_DIR), static_folder=str(STATIC_DIR))
 
@@ -73,234 +67,205 @@ def _resolve_source_pdf(payload: dict) -> tuple[Path, str]:
 def _all_lines(payload: dict) -> list[dict]:
     regions = payload.get("regions", {})
     lines = []
-    for region in ("header", "body", "footnote", "marginalia", "catchword"):
+    for region in SCHEMA_REGIONS:
         values = regions.get(region, [])
         if isinstance(values, list):
             lines.extend([line for line in values if isinstance(line, dict)])
     return lines
 
 
-def _header_lines(payload: dict) -> list[dict]:
-    regions = payload.get("regions", {})
-    values = regions.get("header", [])
+def _footnotes(payload: dict) -> list[dict]:
+    values = payload.get("footnotes", [])
     if not isinstance(values, list):
         return []
-    return [line for line in values if isinstance(line, dict)]
-
-
-def _body_lines(payload: dict) -> list[dict]:
-    regions = payload.get("regions", {})
-    values = regions.get("body", [])
-    if not isinstance(values, list):
-        return []
-    return [line for line in values if isinstance(line, dict)]
-
-
-def _opposite_side(side: str) -> str:
-    if side == "left":
-        return "right"
-    if side == "right":
-        return "left"
-    return ""
-
-
-def _side_for_header_index(index: int, total: int) -> str:
-    if total < 2:
-        return "unknown"
-    if index == 0:
-        return "left"
-    if index == 1:
-        return "right"
-    return "unknown"
-
-
-def _expected_page_number_side(page_num: int | None) -> str:
-    if not isinstance(page_num, int):
-        return ""
-    return "left" if page_num % 2 == 0 else "right"
-
-
-def _contains_page_number_token(text: str, page_num: int) -> bool:
-    return bool(re.search(rf"(?<!\\d){page_num}(?!\\d)", text))
-
-
-def _is_chapter_header(text: str) -> bool:
-    # Accept forms like "CAP. II." and minor punctuation/spacing variants.
-    return bool(re.search(r"\bCAP\.?\s*[IVXLCDM]+\.?\b", text, flags=re.IGNORECASE))
-
-
-def _parse_bool(value: object, default: bool = False) -> bool:
-    if isinstance(value, bool):
-        return value
-    if isinstance(value, str):
-        normalized = value.strip().lower()
-        if normalized in {"true", "1", "yes", "y", "on"}:
-            return True
-        if normalized in {"false", "0", "no", "n", "off", ""}:
-            return False
-    return bool(default)
-
-
-def _parse_side(value: object, default: str = "") -> str:
-    if value is None:
-        return default
-    normalized = str(value).strip().lower()
-    if normalized in SIDE_VALUES:
-        return normalized
-    return default
-
-
-def _refresh_meta_flags(payload: dict) -> None:
-    lines = _all_lines(payload)
-    header_lines = _header_lines(payload)
-    body_lines = _body_lines(payload)
-    ae_pattern = re.compile(r"(ae|AE|æ|Æ)")
-    marker_pattern = re.compile(r"\[[^\]]+\]|\bfn\d+\b|[\*†‡]")
-
-    contains_ae_focus = any(
-        ae_pattern.search(str(line.get("text_gold", ""))) for line in lines
-    )
-    contains_marker_focus = any(
-        bool(line.get("contains_marker", False))
-        or marker_pattern.search(str(line.get("text_gold", "")))
-        for line in lines
-    )
-
-    page_num_value = payload.get("page_num")
-    try:
-        page_num = int(page_num_value)
-    except (TypeError, ValueError):
-        page_num = None
-
-    header_page_number_side = ""
-    header_chapter_side = ""
-    contains_header_page_number = False
-    contains_header_chapter_number = False
-
-    # Prefer explicit header region; if absent, scan first body lines where seeded OCR often keeps header text.
-    candidate_lines = header_lines if header_lines else body_lines[:2]
-    total_candidates = len(candidate_lines)
-    for index, line in enumerate(candidate_lines):
-        text = str(line.get("text_gold", ""))
-        side = _side_for_header_index(index, total_candidates)
-
-        if page_num is not None and _contains_page_number_token(text, page_num):
-            contains_header_page_number = True
-            if side in {"left", "right"} and header_page_number_side == "":
-                header_page_number_side = side
-
-        if _is_chapter_header(text):
-            contains_header_chapter_number = True
-            if side in {"left", "right"} and header_chapter_side == "":
-                header_chapter_side = side
-
-    expected_side = _expected_page_number_side(page_num)
-    if contains_header_page_number and header_page_number_side == "" and expected_side:
-        # Fallback to known layout rule when side is not inferable from header line structure.
-        header_page_number_side = expected_side
-
-    if (
-        contains_header_chapter_number
-        and header_chapter_side == ""
-        and header_page_number_side in {"left", "right"}
-    ):
-        # Based on page design, chapter indicator appears opposite the page number.
-        header_chapter_side = _opposite_side(header_page_number_side)
-
-    header_parity_consistent = bool(
-        contains_header_page_number
-        and header_page_number_side in {"left", "right"}
-        and expected_side in {"left", "right"}
-        and header_page_number_side == expected_side
-    )
-
-    meta = payload.setdefault("meta", {})
-    meta["contains_ae_focus"] = bool(contains_ae_focus)
-    meta["contains_marker_focus"] = bool(contains_marker_focus)
-
-    derived_values: dict[str, object] = {
-        "contains_header_page_number": bool(contains_header_page_number),
-        "contains_header_chapter_number": bool(contains_header_chapter_number),
-        "header_page_number_side": header_page_number_side,
-        "header_chapter_side": header_chapter_side,
-        "header_parity_consistent": bool(header_parity_consistent),
-    }
-
-    for key, derived in derived_values.items():
-        meta[f"derived_{key}"] = derived
-
-    for key, field_type in HEADER_OVERRIDE_FIELDS.items():
-        enabled_key = f"override_{key}_enabled"
-        value_key = f"override_{key}_value"
-        enabled = _parse_bool(meta.get(enabled_key, False), default=False)
-        meta[enabled_key] = enabled
-
-        if field_type == "bool":
-            default_value = bool(derived_values[key])
-            parsed_value = _parse_bool(
-                meta.get(value_key, default_value), default=default_value
-            )
-            meta[value_key] = parsed_value
-            meta[key] = parsed_value if enabled else default_value
-        else:
-            default_value = _parse_side(derived_values[key], default="")
-            parsed_value = _parse_side(
-                meta.get(value_key, default_value), default=default_value
-            )
-            meta[value_key] = parsed_value
-            meta[key] = parsed_value if enabled else default_value
+    return [fn for fn in values if isinstance(fn, dict)]
 
 
 def _validate_payload(payload: dict) -> list[str]:
+    """Slim validator for the post-redesign schema.
+
+    Tolerates older payloads on read: legacy fields and the removed
+    ``regions.footnote`` are simply ignored. We validate the things we need
+    to be sure about for downstream consumers (review_status enums,
+    footnote_id integrity, footnote.kind enum).
+    """
     errors: list[str] = []
-    regions = payload.get("regions", {})
-    footnote_ids = {
+
+    body_line_ids = {
         str(line.get("line_id", ""))
-        for line in regions.get("footnote", [])
+        for line in payload.get("regions", {}).get("body", [])
         if isinstance(line, dict) and line.get("line_id")
+    }
+
+    footnote_ids = {
+        str(fn.get("footnote_id", ""))
+        for fn in _footnotes(payload)
+        if fn.get("footnote_id")
     }
 
     for line in _all_lines(payload):
         line_id = str(line.get("line_id", "<unknown>"))
-        review_status = str(line.get("review_status", ""))
+        review_status = str(line.get("review_status", "draft"))
         if review_status not in ALLOWED_REVIEW_STATUS:
             errors.append(f"{line_id}: invalid review_status '{review_status}'")
 
-        marker_id = str(line.get("marker_id", "")).strip()
-        marker_target = str(line.get("marker_link_target", "")).strip()
-        marker_uncertain = bool(line.get("marker_uncertain", False))
+        # Validate body markers reference real footnotes.
+        markers = line.get("markers")
+        if isinstance(markers, list):
+            for idx, marker in enumerate(markers):
+                if not isinstance(marker, dict):
+                    errors.append(f"{line_id}.markers[{idx}]: not an object")
+                    continue
+                fn_id = str(marker.get("footnote_id", ""))
+                if fn_id and fn_id not in footnote_ids:
+                    errors.append(
+                        f"{line_id}.markers[{idx}]: footnote_id '{fn_id}' not in footnotes[]"
+                    )
 
-        if marker_id and not marker_target and not marker_uncertain:
-            errors.append(f"{line_id}: marker_id set but marker_link_target is empty")
-
-        if marker_target and marker_target not in footnote_ids:
+    for idx, fn in enumerate(_footnotes(payload)):
+        fn_id = str(fn.get("footnote_id", f"<idx{idx}>"))
+        kind = str(fn.get("kind", "citation"))
+        if kind not in ALLOWED_FOOTNOTE_KIND:
+            errors.append(f"footnotes[{fn_id}]: invalid kind '{kind}'")
+        review_status = str(fn.get("review_status", "draft"))
+        if review_status not in ALLOWED_REVIEW_STATUS:
             errors.append(
-                f"{line_id}: marker_link_target '{marker_target}' not found in footnote line_ids"
+                f"footnotes[{fn_id}]: invalid review_status '{review_status}'"
             )
-
-    meta_review_status = str(payload.get("meta", {}).get("review_status", ""))
-    if meta_review_status and meta_review_status not in ALLOWED_REVIEW_STATUS:
-        errors.append(f"meta.review_status: invalid value '{meta_review_status}'")
+        body_line_id = str(fn.get("body_line_id", ""))
+        if body_line_id and body_line_id not in body_line_ids:
+            errors.append(
+                f"footnotes[{fn_id}]: body_line_id '{body_line_id}' not in body line_ids"
+            )
 
     meta = payload.get("meta", {})
     if not isinstance(meta, dict):
         errors.append("meta: must be an object")
         return errors
 
-    for key, field_type in HEADER_OVERRIDE_FIELDS.items():
-        enabled_key = f"override_{key}_enabled"
-        value_key = f"override_{key}_value"
-        enabled = _parse_bool(meta.get(enabled_key, False), default=False)
-        if not enabled:
-            continue
-
-        raw_value = meta.get(value_key)
-        if field_type == "side":
-            normalized = _parse_side(raw_value, default="<invalid>")
-            if normalized not in SIDE_VALUES:
-                errors.append(f"meta.{value_key}: invalid side '{raw_value}'")
+    meta_review_status = str(meta.get("review_status", "draft"))
+    if meta_review_status and meta_review_status not in ALLOWED_REVIEW_STATUS:
+        errors.append(f"meta.review_status: invalid value '{meta_review_status}'")
 
     return errors
+
+
+# ---------------------------------------------------------------------------
+# Edit log: append per-save diffs to a sidecar JSONL for prompt refinement.
+# ---------------------------------------------------------------------------
+
+# Fields we track per line/footnote/page-meta when computing the diff.
+_LINE_DIFF_FIELDS = ("text_gold", "marker_id", "notes", "review_status")
+_FOOTNOTE_DIFF_FIELDS = (
+    "text_gold",
+    "kind",
+    "marker_number",
+    "body_line_id",
+    "notes",
+    "review_status",
+)
+_PAGE_META_DIFF_FIELDS = (
+    "annotation_status",
+    "review_status",
+    "notes",
+    "ocr_page_summary",
+)
+_PAGE_TOPLEVEL_DIFF_FIELDS = ("page_num", "source_pdf")
+
+
+def _index_by(items, key: str) -> dict:
+    out: dict = {}
+    if not isinstance(items, list):
+        return out
+    for item in items:
+        if isinstance(item, dict):
+            value = item.get(key)
+            if value:
+                out[str(value)] = item
+    return out
+
+
+def _diff_payloads(old: dict, new: dict) -> list[dict]:
+    """Compute a flat list of edit entries between two payloads."""
+    entries: list[dict] = []
+    page_id = str(new.get("page_id") or old.get("page_id") or "")
+    reviewer = str(new.get("meta", {}).get("reviewer", "")) if isinstance(new.get("meta"), dict) else ""
+    timestamp = _dt.datetime.now(_dt.timezone.utc).isoformat()
+
+    def emit(scope: str, target_id: str, field: str, before, after) -> None:
+        if before == after:
+            return
+        entries.append(
+            {
+                "ts": timestamp,
+                "page_id": page_id,
+                "scope": scope,
+                "target_id": target_id,
+                "field": field,
+                "before": before,
+                "after": after,
+                "reviewer": reviewer,
+            }
+        )
+
+    # Page-level top-level fields.
+    for field in _PAGE_TOPLEVEL_DIFF_FIELDS:
+        emit("page", page_id, field, old.get(field), new.get(field))
+
+    # Page meta.
+    old_meta = old.get("meta") if isinstance(old.get("meta"), dict) else {}
+    new_meta = new.get("meta") if isinstance(new.get("meta"), dict) else {}
+    for field in _PAGE_META_DIFF_FIELDS:
+        emit("page_meta", page_id, field, old_meta.get(field), new_meta.get(field))
+
+    # Lines (across all current regions).
+    old_lines = {
+        str(line.get("line_id", "")): line
+        for line in _all_lines(old)
+        if line.get("line_id")
+    }
+    new_lines = {
+        str(line.get("line_id", "")): line
+        for line in _all_lines(new)
+        if line.get("line_id")
+    }
+    for line_id, new_line in new_lines.items():
+        old_line = old_lines.get(line_id, {})
+        for field in _LINE_DIFF_FIELDS:
+            emit("line", line_id, field, old_line.get(field), new_line.get(field))
+        # Marker structure changes (insert/delete/reorder) -> single entry.
+        old_markers = old_line.get("markers")
+        new_markers = new_line.get("markers")
+        if (old_markers or []) != (new_markers or []):
+            emit("body_marker", line_id, "markers", old_markers, new_markers)
+
+    # Footnotes (matched by footnote_id).
+    old_fn = _index_by(old.get("footnotes"), "footnote_id")
+    new_fn = _index_by(new.get("footnotes"), "footnote_id")
+    for fn_id, new_node in new_fn.items():
+        old_node = old_fn.get(fn_id, {})
+        for field in _FOOTNOTE_DIFF_FIELDS:
+            emit("footnote", fn_id, field, old_node.get(field), new_node.get(field))
+    for fn_id in old_fn.keys() - new_fn.keys():
+        emit("footnote", fn_id, "_deleted", old_fn[fn_id], None)
+    for fn_id in new_fn.keys() - old_fn.keys():
+        emit("footnote", fn_id, "_added", None, new_fn[fn_id])
+
+    return entries
+
+
+def _edits_path(page_id: str) -> Path:
+    return ANNOTATIONS_DIR / f"page_{page_id}.edits.jsonl"
+
+
+def _append_edit_log(page_id: str, entries: list[dict]) -> None:
+    if not entries:
+        return
+    path = _edits_path(page_id)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as handle:
+        for entry in entries:
+            handle.write(json.dumps(entry, ensure_ascii=False) + "\n")
 
 
 @app.get("/")
@@ -351,9 +316,18 @@ def api_save_page(page_id: str):
     if errors:
         return jsonify({"ok": False, "errors": errors}), 400
 
-    _refresh_meta_flags(incoming)
+    # Compute edit log entries against the on-disk payload before overwriting.
+    try:
+        existing = _read_payload(path)
+    except Exception:
+        existing = {}
+    edits = _diff_payloads(existing, incoming)
+    _append_edit_log(page_id, edits)
+
     _write_payload_atomic(path, incoming)
-    return jsonify({"ok": True, "meta": incoming.get("meta", {})})
+    return jsonify(
+        {"ok": True, "meta": incoming.get("meta", {}), "edits_recorded": len(edits)}
+    )
 
 
 @app.get("/pdf/<page_id>")
@@ -373,6 +347,48 @@ def page_pdf(page_id: str):
         return f"Source PDF not found: {source_pdf_value}", 404
 
     return send_file(source_pdf)
+
+
+@app.get("/source-pdf/<path:pdf_name>")
+def source_pdf_file(pdf_name: str):
+    """Stream a PDF directly from 00_source_pdf/ by filename."""
+    # Reject paths that try to escape the source dir.
+    candidate = (SOURCE_PDF_DIR / pdf_name).resolve()
+    try:
+        candidate.relative_to(SOURCE_PDF_DIR.resolve())
+    except ValueError:
+        abort(400)
+    if not candidate.exists() or candidate.suffix.lower() != ".pdf":
+        abort(404)
+    return send_file(candidate)
+
+
+@app.get("/pdfjs-source")
+def pdfjs_source_viewer():
+    """Render the PDF.js viewer for an arbitrary source PDF + page (no annotation required)."""
+    pdf_name = request.args.get("pdf", default="", type=str).strip()
+    if not pdf_name:
+        abort(400)
+    candidate = (SOURCE_PDF_DIR / pdf_name).resolve()
+    try:
+        candidate.relative_to(SOURCE_PDF_DIR.resolve())
+    except ValueError:
+        abort(400)
+    if not candidate.exists() or candidate.suffix.lower() != ".pdf":
+        abort(404)
+
+    try:
+        initial_page = int(request.args.get("page", default="1", type=str))
+    except (TypeError, ValueError):
+        initial_page = 1
+    if initial_page < 1:
+        initial_page = 1
+
+    return render_template(
+        "pdf_viewer.html",
+        pdf_url=url_for("source_pdf_file", pdf_name=pdf_name),
+        initial_page=initial_page,
+    )
 
 
 @app.get("/pdfjs/<page_id>")

--- a/08_working_scratch/phase3b/ui/static/annotation_ui.css
+++ b/08_working_scratch/phase3b/ui/static/annotation_ui.css
@@ -101,6 +101,40 @@ body {
   overflow: auto;
 }
 
+.pdf-pane-header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  margin-bottom: 0.3rem;
+}
+.pdf-pane-header h2 {
+  margin: 0;
+}
+.pdf-pane-meta {
+  display: flex;
+  align-items: baseline;
+  gap: 0.4rem;
+  font-size: 0.85rem;
+  color: var(--text);
+}
+.pdf-pane-meta-label {
+  color: #6b6052;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  font-size: 0.7rem;
+}
+.pdf-pane-meta-value {
+  font-weight: 600;
+  max-width: 24em;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  display: inline-block;
+  vertical-align: bottom;
+}
+
 .meta-grid {
   display: grid;
   grid-template-columns: repeat(3, minmax(140px, 1fr));
@@ -175,6 +209,218 @@ input[type="text"], select, textarea {
 
 .inline-check input { width: auto; }
 
+
+/* === Phase C redesign === */
+
+.meta-card {
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  padding: 0.6rem;
+  margin-bottom: 0.6rem;
+  background: #fffaf0;
+}
+.meta-card .meta-grid {
+  grid-template-columns: repeat(5, minmax(120px, 1fr));
+}
+.meta-provenance {
+  margin-top: 0.4rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  font-size: 0.78rem;
+  color: #5b513f;
+}
+.meta-prov-label {
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  font-weight: 700;
+  margin-right: 0.2rem;
+}
+.meta-prov-value { margin-right: 0.6rem; }
+
+.region-section {
+  margin-top: 0.7rem;
+  border-top: 1px dashed var(--line);
+  padding-top: 0.5rem;
+}
+.region-section h2 {
+  font-size: 1rem;
+  margin: 0;
+}
+
+.body-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 2fr) minmax(0, 1fr);
+  gap: 0.4rem;
+  align-items: start;
+}
+.body-row {
+  display: contents;
+}
+.body-cell, .marg-cell {
+  min-width: 0;
+}
+
+.line-card-body { background: #fcfaf3; }
+.line-card-marginalia {
+  background: #f3eedc;
+  border-color: #c2b58f;
+  font-size: 0.88rem;
+}
+.line-card-header { background: #f6efde; }
+.line-card-catchword { background: #f6efde; font-style: italic; }
+
+.marginalia-block {
+  border: 1px dashed #b39d65;
+  border-radius: 5px;
+  padding: 0.25rem;
+  background: #fbf6e3;
+}
+.marginalia-block .line-card-marginalia {
+  border-style: dotted;
+  margin-bottom: 0.25rem;
+}
+.marginalia-block .line-card-marginalia:last-child {
+  margin-bottom: 0;
+}
+
+.unanchored-marginalia {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background: var(--panel);
+  padding: 0.25rem 0;
+  margin-bottom: 0.4rem;
+}
+.unanchored-heading {
+  font-size: 0.78rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: #8a3a25;
+  margin-bottom: 0.2rem;
+  font-weight: 700;
+}
+
+.line-row {
+  display: flex;
+  gap: 0.4rem;
+  align-items: center;
+  margin-top: 0.25rem;
+  flex-wrap: wrap;
+}
+.line-row .anchor-row { flex: 0 0 auto; font-size: 0.8rem; }
+.line-row .anchor-row select { min-width: 14ch; }
+.line-row .notes-field { flex: 1 1 auto; min-width: 12ch; }
+
+.add-marker-btn {
+  border: 1px dashed var(--accent);
+  background: transparent;
+  color: var(--accent);
+  border-radius: 3px;
+  font-size: 0.72rem;
+  padding: 0.1rem 0.4rem;
+  cursor: pointer;
+}
+
+.line-head-right {
+  display: flex;
+  gap: 0.3rem;
+  align-items: center;
+}
+
+.review-status-chip {
+  width: auto;
+  font-size: 0.75rem;
+  padding: 0.1rem 0.3rem;
+  margin-top: 0;
+}
+
+.marker-id-mini {
+  width: 4ch;
+  font-size: 0.78rem;
+  padding: 0.1rem 0.25rem;
+  margin-top: 0;
+}
+
+.marker-badge {
+  display: inline-block;
+  background: var(--accent);
+  color: #fff;
+  border-radius: 999px;
+  padding: 0 0.35em;
+  font-size: 0.65em;
+  font-weight: 700;
+  margin: 0 0.15em;
+  vertical-align: super;
+  line-height: 1.4;
+  min-width: 1.4em;
+  text-align: center;
+}
+
+.body-markers-preview {
+  font-size: 0.95rem;
+  color: #5b513f;
+  margin-top: 0.15rem;
+  min-height: 0.9rem;
+}
+
+.footnote-card {
+  border: 1px solid #c4b48e;
+  background: #fbf5df;
+  border-radius: 5px;
+  padding: 0.4rem;
+  margin-bottom: 0.4rem;
+}
+.footnote-head {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.82rem;
+  flex-wrap: wrap;
+  margin-bottom: 0.25rem;
+}
+.footnote-marker-badge {
+  background: var(--accent);
+  color: #fff;
+  border-radius: 999px;
+  padding: 0.05em 0.5em;
+  font-weight: 700;
+  font-size: 0.75rem;
+  vertical-align: middle;
+}
+.footnote-id {
+  font-family: ui-monospace, "Cascadia Code", Consolas, monospace;
+  font-size: 0.72rem;
+  color: #6b6052;
+}
+.footnote-anchor {
+  font-size: 0.78rem;
+  color: #6b6052;
+}
+.footnote-kind { width: auto; margin-top: 0; font-size: 0.78rem; padding: 0.15rem 0.3rem; }
+.footnote-empty {
+  color: #8a7e64;
+  font-style: italic;
+  font-size: 0.85rem;
+  padding: 0.3rem 0;
+}
+.footnote-remove-btn {
+  border: 1px solid #b94834;
+  background: #fff4f1;
+  color: #922a1b;
+  border-radius: 3px;
+  font-size: 0.7rem;
+  padding: 0.1rem 0.35rem;
+  cursor: pointer;
+  margin-left: auto;
+}
+
+.text-gold {
+  font-family: "Source Serif 4", Georgia, serif;
+  font-size: 0.95rem;
+  resize: vertical;
+}
+
 .text-gold {
   min-height: 2.1rem;
 }
@@ -193,3 +439,6 @@ input[type="text"], select, textarea {
   }
   #pdfFrame { height: 60vh; }
 }
+
+
+/* === Phase C redesign === */

--- a/08_working_scratch/phase3b/ui/static/annotation_ui.js
+++ b/08_working_scratch/phase3b/ui/static/annotation_ui.js
@@ -1,94 +1,73 @@
+// Phase 3b annotator — Gemini-OCR redesign.
+// Document-shaped editor: page-meta card + header + body|marginalia 2-col grid
+// + auto-numbered footnotes + catchword. Body markers (footnote refs) are
+// stored as structured records on each body line; superscripts in the rendered
+// view are derived from `markers[]`, not free-typed.
+
 let currentPayload = null;
 let activeInput = null;
 let currentPdfSource = "";
 const DEFAULT_REVIEWER = "Paul Boys";
 
+// ---------------------------------------------------------------------------
+// Top bar / status / page selector
+// ---------------------------------------------------------------------------
 const pageSelect = document.getElementById("pageSelect");
 const loadBtn = document.getElementById("loadBtn");
 const saveBtn = document.getElementById("saveBtn");
 const statusEl = document.getElementById("status");
 const pdfFrame = document.getElementById("pdfFrame");
+const pdfPaneSourceName = document.getElementById("pdfPaneSourceName");
+const pdfPanePageNum = document.getElementById("pdfPanePageNum");
 
+// Page meta fields.
+const metaPageNum = document.getElementById("metaPageNum");
+const metaSourcePdf = document.getElementById("metaSourcePdf");
 const metaReviewer = document.getElementById("metaReviewer");
 const metaAnnotationStatus = document.getElementById("metaAnnotationStatus");
 const metaReviewStatus = document.getElementById("metaReviewStatus");
 const metaNotes = document.getElementById("metaNotes");
+const metaOcrPageSummary = document.getElementById("metaOcrPageSummary");
+const metaOcrEngine = document.getElementById("metaOcrEngine");
+const metaOcrModel = document.getElementById("metaOcrModel");
+const metaOcrLang = document.getElementById("metaOcrLang");
 
-const headerTable = document.getElementById("headerTable");
-const bodyTable = document.getElementById("bodyTable");
-const footnoteTable = document.getElementById("footnoteTable");
+// Region containers.
+const headerContainer = document.getElementById("headerContainer");
+const bodyContainer = document.getElementById("bodyContainer");
+const unanchoredMarginaliaContainer = document.getElementById(
+  "unanchoredMarginaliaContainer"
+);
+const footnoteContainer = document.getElementById("footnoteContainer");
+const catchwordContainer = document.getElementById("catchwordContainer");
+
 const addHeaderBtn = document.getElementById("addHeaderBtn");
+const addBodyBtn = document.getElementById("addBodyBtn");
 const addFootnoteBtn = document.getElementById("addFootnoteBtn");
+const addCatchwordBtn = document.getElementById("addCatchwordBtn");
 
+// Glyph bar.
 const glyphBar = document.getElementById("glyphBar");
 const superscriptInput = document.getElementById("superscriptInput");
 const insertSuperscriptRawBtn = document.getElementById("insertSuperscriptRawBtn");
 const insertSuperscriptBtn = document.getElementById("insertSuperscriptBtn");
 
-const TRACKED_GLYPHS = ["æ", "Æ", "œ", "Œ", "Ↄ", "ↄ", "ↀ", "ↁ", "ↂ", "ᵃ", "ᵇ", "ᶜ", "ᵈ", "ᵉ", "ⁿ"];
-const FOOTNOTE_MARKERS = Array.from({ length: 26 }, (_, idx) => String.fromCharCode(97 + idx));
+const FOOTNOTE_KINDS = ["citation", "gloss", "cross_ref", "not_a_note", "other"];
+const REVIEW_STATUSES = ["draft", "reviewed", "locked"];
+
 const SUPERSCRIPT_MAP = {
-  a: "ᵃ",
-  b: "ᵇ",
-  c: "ᶜ",
-  d: "ᵈ",
-  e: "ᵉ",
-  f: "ᶠ",
-  g: "ᵍ",
-  h: "ʰ",
-  i: "ᶦ",
-  j: "ʲ",
-  k: "ᵏ",
-  l: "ˡ",
-  m: "ᵐ",
-  n: "ⁿ",
-  o: "ᵒ",
-  p: "ᵖ",
-  r: "ʳ",
-  s: "ˢ",
-  t: "ᵗ",
-  u: "ᵘ",
-  v: "ᵛ",
-  w: "ʷ",
-  x: "ˣ",
-  y: "ʸ",
-  z: "ᶻ",
-  A: "ᴬ",
-  B: "ᴮ",
-  D: "ᴰ",
-  E: "ᴱ",
-  G: "ᴳ",
-  H: "ᴴ",
-  I: "ᴵ",
-  J: "ᴶ",
-  K: "ᴷ",
-  L: "ᴸ",
-  M: "ᴹ",
-  N: "ᴺ",
-  O: "ᴼ",
-  P: "ᴾ",
-  R: "ᴿ",
-  T: "ᵀ",
-  U: "ᵁ",
-  V: "ⱽ",
-  W: "ᵂ",
-  0: "⁰",
-  1: "¹",
-  2: "²",
-  3: "³",
-  4: "⁴",
-  5: "⁵",
-  6: "⁶",
-  7: "⁷",
-  8: "⁸",
-  9: "⁹",
-  "+": "⁺",
-  "-": "⁻",
-  "=": "⁼",
-  "(": "⁽",
-  ")": "⁾",
+  a: "ᵃ", b: "ᵇ", c: "ᶜ", d: "ᵈ", e: "ᵉ", f: "ᶠ", g: "ᵍ", h: "ʰ", i: "ᶦ",
+  j: "ʲ", k: "ᵏ", l: "ˡ", m: "ᵐ", n: "ⁿ", o: "ᵒ", p: "ᵖ", r: "ʳ", s: "ˢ",
+  t: "ᵗ", u: "ᵘ", v: "ᵛ", w: "ʷ", x: "ˣ", y: "ʸ", z: "ᶻ",
+  A: "ᴬ", B: "ᴮ", D: "ᴰ", E: "ᴱ", G: "ᴳ", H: "ᴴ", I: "ᴵ", J: "ᴶ", K: "ᴷ",
+  L: "ᴸ", M: "ᴹ", N: "ᴺ", O: "ᴼ", P: "ᴾ", R: "ᴿ", T: "ᵀ", U: "ᵁ", V: "ⱽ", W: "ᵂ",
+  0: "⁰", 1: "¹", 2: "²", 3: "³", 4: "⁴", 5: "⁵", 6: "⁶", 7: "⁷", 8: "⁸", 9: "⁹",
+  "+": "⁺", "-": "⁻", "=": "⁼", "(": "⁽", ")": "⁾",
 };
 
+// ---------------------------------------------------------------------------
+// Utilities
+// ---------------------------------------------------------------------------
 function escapeHtml(value) {
   return String(value)
     .replaceAll("&", "&amp;")
@@ -103,14 +82,41 @@ function setStatus(message, isError = false) {
   statusEl.style.color = isError ? "#a30000" : "#224b2b";
 }
 
+function updatePdfPaneHeader(sourcePdfKey, pageNum) {
+  if (pdfPaneSourceName) {
+    const baseName = String(sourcePdfKey || "").split(/[\\/]/).pop() || "";
+    pdfPaneSourceName.textContent = baseName || "\u2014";
+    pdfPaneSourceName.title = String(sourcePdfKey || "");
+  }
+  if (pdfPanePageNum) {
+    pdfPanePageNum.textContent =
+      Number.isFinite(pageNum) && pageNum > 0 ? String(pageNum) : "\u2014";
+  }
+}
+
 function clone(obj) {
   return JSON.parse(JSON.stringify(obj));
+}
+
+function pad4(n) { return String(n).padStart(4, "0"); }
+
+function makeLineId(pageId, region, ordinal) {
+  return `${pageId}_${region}_l${pad4(ordinal)}`;
+}
+
+function nextFootnoteId(pageId, footnotes) {
+  const used = new Set((footnotes || []).map((fn) => String(fn.footnote_id)));
+  for (let i = 1; i < 10000; i++) {
+    const candidate = `${pageId}_fn_${String(i).padStart(3, "0")}`;
+    if (!used.has(candidate)) return candidate;
+  }
+  return `${pageId}_fn_${Date.now()}`;
 }
 
 function bindFocusTracking(container) {
   container.querySelectorAll("input, textarea, select").forEach((el) => {
     el.addEventListener("focus", () => {
-      if (el.classList.contains("text-gold") || el.classList.contains("marker-field") || el.classList.contains("notes-field")) {
+      if (el.classList.contains("text-gold") || el.classList.contains("notes-field")) {
         activeInput = el;
       }
     });
@@ -131,9 +137,8 @@ function insertGlyph(text) {
 }
 
 function toSuperscript(value) {
-  const text = String(value || "");
   let output = "";
-  for (const ch of text) {
+  for (const ch of String(value || "")) {
     output += SUPERSCRIPT_MAP[ch] || ch;
   }
   return output;
@@ -142,394 +147,639 @@ function toSuperscript(value) {
 function insertCustomSuperscript(rawMode = false) {
   if (!superscriptInput) return;
   const value = superscriptInput.value || "";
-  if (!value.trim()) {
-    return;
+  if (!value.trim()) return;
+  insertGlyph(rawMode ? value : toSuperscript(value));
+}
+
+// ---------------------------------------------------------------------------
+// Schema helpers (load / save normalization)
+// ---------------------------------------------------------------------------
+const REGION_NAMES = ["header", "body", "marginalia", "catchword"];
+
+function normalizePayload(payload) {
+  if (!payload || typeof payload !== "object") return;
+  payload.regions = payload.regions || {};
+  REGION_NAMES.forEach((r) => {
+    if (!Array.isArray(payload.regions[r])) payload.regions[r] = [];
+  });
+  // Ignore legacy regions.footnote (kept on disk for older files but unused).
+  if (Array.isArray(payload.regions.footnote)) {
+    delete payload.regions.footnote;
   }
-  const text = rawMode ? value : toSuperscript(value);
-  insertGlyph(text);
-}
+  if (!Array.isArray(payload.footnotes)) payload.footnotes = [];
 
-function pad4(number) {
-  return String(number).padStart(4, "0");
-}
-
-function makeLineId(pageId, regionName, ordinal) {
-  return `${pageId}_${regionName}_l${pad4(ordinal)}`;
-}
-
-function createEmptyLine(pageId, regionName, ordinal) {
-  return {
-    page_id: pageId,
-    region: regionName,
-    line_id: makeLineId(pageId, regionName, ordinal),
-    text_gold: "",
-    contains_ae_target: false,
-    contains_marker: false,
-    marker_id: "",
-    marker_link_target: "",
-    uncertain_ae: false,
-    marker_uncertain: false,
-    reviewer: DEFAULT_REVIEWER,
-    review_status: "draft",
-    notes: "",
-    glyph_counts: {},
-  };
-}
-
-function hasAeTarget(text) {
-  const value = String(text || "");
-  return /(ae|æ)/i.test(value);
-}
-
-function computeGlyphCounts(text) {
-  const value = String(text || "");
-  const counts = {};
-  TRACKED_GLYPHS.forEach((glyph) => {
-    let count = 0;
-    for (const ch of value) {
-      if (ch === glyph) {
-        count += 1;
-      }
-    }
-    if (count > 0) {
-      counts[glyph] = count;
+  payload.regions.body.forEach((line) => {
+    if (line && typeof line === "object" && !Array.isArray(line.markers)) {
+      line.markers = [];
     }
   });
-  return counts;
-}
 
-function formatGlyphCounts(counts) {
-  const entries = Object.entries(counts || {});
-  if (!entries.length) return "none";
-  return entries.map(([glyph, count]) => `${glyph}:${count}`).join(", ");
-}
-
-function normalizeMarkerIdForRegion(markerId, regionName) {
-  const value = String(markerId || "").trim();
-  if (regionName !== "footnote") {
-    return value;
-  }
-  if (!value) {
-    return "";
-  }
-  const normalized = value.toLowerCase();
-  return FOOTNOTE_MARKERS.includes(normalized) ? normalized : "";
-}
-
-function refreshDerivedLineFields(line, card = null) {
-  line.contains_ae_target = hasAeTarget(line.text_gold || "");
-  line.glyph_counts = computeGlyphCounts(line.text_gold || "");
-
-  if (!card) return;
-
-  const aeCheckbox = card.querySelector('input[data-field="contains_ae_target"]');
-  if (aeCheckbox) {
-    aeCheckbox.checked = Boolean(line.contains_ae_target);
-  }
-
-  const glyphSummaryEl = card.querySelector(".glyph-summary");
-  if (glyphSummaryEl) {
-    glyphSummaryEl.value = formatGlyphCounts(line.glyph_counts);
-  }
+  payload.meta = payload.meta || {};
+  payload.meta.reviewer = DEFAULT_REVIEWER;
 }
 
 function applyDefaultReviewer(payload) {
   if (!payload) return;
   payload.meta = payload.meta || {};
   payload.meta.reviewer = DEFAULT_REVIEWER;
-  payload.regions = payload.regions || {};
-  ["header", "body", "footnote"].forEach((regionName) => {
-    const lines = payload.regions[regionName];
-    if (!Array.isArray(lines)) return;
-    lines.forEach((line) => {
-      if (line && typeof line === "object") {
-        line.reviewer = DEFAULT_REVIEWER;
-      }
+  REGION_NAMES.forEach((r) => {
+    (payload.regions[r] || []).forEach((line) => {
+      if (line && typeof line === "object") line.reviewer = DEFAULT_REVIEWER;
     });
+  });
+  (payload.footnotes || []).forEach((fn) => {
+    if (fn && typeof fn === "object") fn.reviewer = DEFAULT_REVIEWER;
   });
 }
 
 function getNextOrdinal(regionName) {
-  const pageId = currentPayload?.page_id || pageSelect.value;
   const lines = currentPayload?.regions?.[regionName] || [];
-  let maxOrdinal = 0;
+  let max = 0;
+  const pageId = currentPayload?.page_id || pageSelect.value;
   const pattern = new RegExp(`^${pageId}_${regionName}_l(\\d{4})$`);
   lines.forEach((line, idx) => {
-    const candidate = String(line?.line_id || "");
-    const match = candidate.match(pattern);
-    if (match) {
-      maxOrdinal = Math.max(maxOrdinal, Number(match[1]));
-    } else {
-      maxOrdinal = Math.max(maxOrdinal, idx + 1);
-    }
+    const match = String(line?.line_id || "").match(pattern);
+    if (match) max = Math.max(max, Number(match[1]));
+    else max = Math.max(max, idx + 1);
   });
-  return maxOrdinal + 1;
+  return max + 1;
 }
 
-function normalizeRegionLines(regionName) {
-  if (!currentPayload) return;
-  const pageId = currentPayload.page_id || pageSelect.value;
-  currentPayload.regions = currentPayload.regions || {};
-  const regionValue = currentPayload.regions[regionName];
-  if (!Array.isArray(regionValue)) {
-    currentPayload.regions[regionName] = [];
-    return;
-  }
-
-  currentPayload.regions[regionName] = regionValue.map((line, idx) => {
-    if (typeof line === "string") {
-      const newLine = createEmptyLine(pageId, regionName, idx + 1);
-      newLine.text_gold = line;
-      return newLine;
-    }
-
-    if (!line || typeof line !== "object") {
-      return createEmptyLine(pageId, regionName, idx + 1);
-    }
-
-    return {
-      page_id: line.page_id || pageId,
-      region: line.region || regionName,
-      line_id: line.line_id || makeLineId(pageId, regionName, idx + 1),
-      text_gold: line.text_gold || "",
-      contains_ae_target: hasAeTarget(line.text_gold || ""),
-      contains_marker: Boolean(line.contains_marker),
-      marker_id: normalizeMarkerIdForRegion(line.marker_id || "", regionName),
-      marker_link_target: line.marker_link_target || "",
-      uncertain_ae: Boolean(line.uncertain_ae),
-      marker_uncertain: Boolean(line.marker_uncertain),
-      reviewer: DEFAULT_REVIEWER,
-      review_status: line.review_status || "draft",
-      notes: line.notes || "",
-      glyph_counts: computeGlyphCounts(line.text_gold || ""),
-    };
-  });
+function createEmptyLine(pageId, regionName, ordinal) {
+  const line = {
+    page_id: pageId,
+    region: regionName,
+    line_id: makeLineId(pageId, regionName, ordinal),
+    text_gold: "",
+    text_ocr_original: "",
+    marker_id: "",
+    review_status: "draft",
+    reviewer: DEFAULT_REVIEWER,
+    notes: "",
+  };
+  if (regionName === "body") line.markers = [];
+  return line;
 }
 
-function renumberRegionLines(regionName, removedLineIds = []) {
-  if (!currentPayload) return;
-  const pageId = currentPayload.page_id || pageSelect.value;
-  const regionLines = currentPayload.regions?.[regionName] || [];
-  const idMap = new Map();
+// ---------------------------------------------------------------------------
+// Footnote logic: numbering, body-line rendering, marker insertion
+// ---------------------------------------------------------------------------
+function bodyLineIndex(pageId, footnote, bodyLines) {
+  const target = String(footnote.body_line_id || "");
+  const idx = bodyLines.findIndex((line) => String(line.line_id) === target);
+  return idx;
+}
 
-  regionLines.forEach((line, idx) => {
-    const oldId = String(line.line_id || "");
-    const newId = makeLineId(pageId, regionName, idx + 1);
-    line.page_id = pageId;
-    line.region = regionName;
-    line.line_id = newId;
-    if (oldId) {
-      idMap.set(oldId, newId);
+function renumberFootnotes() {
+  if (!currentPayload) return;
+  const bodyLines = currentPayload.regions.body || [];
+  const fns = currentPayload.footnotes || [];
+  // Sort: anchored (by body line position) first, then orphans in their
+  // existing relative order.
+  const orphanOrder = new Map();
+  fns.forEach((fn, i) => {
+    if (!fn.body_line_id) orphanOrder.set(fn.footnote_id, i);
+  });
+  const sorted = fns.slice().sort((a, b) => {
+    const ia = bodyLineIndex(null, a, bodyLines);
+    const ib = bodyLineIndex(null, b, bodyLines);
+    const aOrphan = ia < 0;
+    const bOrphan = ib < 0;
+    if (aOrphan && !bOrphan) return 1;
+    if (!aOrphan && bOrphan) return -1;
+    if (aOrphan && bOrphan) {
+      return (orphanOrder.get(a.footnote_id) ?? 0) - (orphanOrder.get(b.footnote_id) ?? 0);
     }
+    return ia - ib;
   });
 
-  if (regionName === "footnote") {
-    const bodyLines = currentPayload.regions?.body || [];
-    bodyLines.forEach((line) => {
-      const target = String(line.marker_link_target || "");
-      if (!target) return;
-      if (idMap.has(target)) {
-        line.marker_link_target = idMap.get(target);
-      } else if (removedLineIds.includes(target)) {
-        line.marker_link_target = "";
+  // Assign sequential marker_number; rebuild markers[] on body lines.
+  bodyLines.forEach((line) => { line.markers = []; });
+  sorted.forEach((fn, idx) => {
+    fn.marker_number = idx + 1;
+    if (fn.body_line_id) {
+      const bodyLine = bodyLines.find((l) => String(l.line_id) === String(fn.body_line_id));
+      if (bodyLine) {
+        bodyLine.markers = bodyLine.markers || [];
+        bodyLine.markers.push({
+          number: idx + 1,
+          footnote_id: fn.footnote_id,
+          char_offset: null,
+        });
       }
-    });
-  }
+    }
+  });
+  currentPayload.footnotes = sorted;
 }
 
-function buildLineCard(line, idx, regionName, options = {}) {
-  refreshDerivedLineFields(line);
+function renderBodyTextWithMarkers(line) {
+  // Returns HTML: text_gold escaped + <sup> markers appended at end of line.
+  // Markers with char_offset null render at end-of-line (default).
+  const safe = escapeHtml(line.text_gold || "");
+  const markers = (line.markers || []).slice().sort((a, b) => {
+    const oa = a.char_offset == null ? Number.MAX_SAFE_INTEGER : a.char_offset;
+    const ob = b.char_offset == null ? Number.MAX_SAFE_INTEGER : b.char_offset;
+    return oa - ob;
+  });
+  if (markers.length === 0) return safe;
+  // For now char_offset positions are not honoured for rendering; all markers
+  // stack at end. The structure is preserved for future positional rendering.
+  const sups = markers
+    .map((m) => `<sup class="marker-badge" data-fn-id="${escapeHtml(m.footnote_id)}" title="footnote ${m.number}">${m.number}</sup>`)
+    .join("");
+  return `${safe} ${sups}`;
+}
 
+// ---------------------------------------------------------------------------
+// Card builders
+// ---------------------------------------------------------------------------
+function buildLineCardSimple(line, regionName, options = {}) {
   const card = document.createElement("div");
-  card.className = "line-card";
-  const safeLineId = escapeHtml(line.line_id || `${regionName}_${idx + 1}`);
-  const safeRegionName = escapeHtml(regionName);
-  const safeTextGold = escapeHtml(line.text_gold || "");
-  const safeMarkerId = escapeHtml(line.marker_id || "");
-  const safeMarkerTarget = escapeHtml(line.marker_link_target || "");
-  const safeReviewer = escapeHtml(line.reviewer || "");
+  card.className = `line-card line-card-${regionName}`;
+  card.dataset.lineId = line.line_id || "";
+
+  const safeId = escapeHtml(line.line_id || regionName);
+  const safeText = escapeHtml(line.text_gold || "");
   const safeNotes = escapeHtml(line.notes || "");
-  const safeGlyphSummary = escapeHtml(formatGlyphCounts(line.glyph_counts));
-  const markerIdControl = regionName === "footnote"
-    ? `<label>marker_id
-        <select class="marker-field" data-field="marker_id">
-          <option value=""></option>
-          ${FOOTNOTE_MARKERS.map((marker) => `<option value="${marker}" ${line.marker_id === marker ? "selected" : ""}>${marker}</option>`).join("")}
-        </select>
-      </label>`
-    : `<label>marker_id <input class="marker-field" type="text" data-field="marker_id" value="${safeMarkerId}"></label>`;
+  const reviewOpts = REVIEW_STATUSES.map(
+    (s) => `<option value="${s}" ${line.review_status === s ? "selected" : ""}>${s}</option>`
+  ).join("");
 
   card.innerHTML = `
     <div class="line-head">
-      <span>${safeLineId}</span>
-      <div>
-        <span>${safeRegionName}</span>
+      <span class="line-id">${safeId}</span>
+      <div class="line-head-right">
+        <select class="review-status-chip" data-field="review_status">${reviewOpts}</select>
         ${options.showRemove ? '<button type="button" class="line-remove-btn">Remove</button>' : ""}
       </div>
     </div>
-    <label>text_gold
-      <textarea class="text-gold" data-field="text_gold" rows="2">${safeTextGold}</textarea>
-    </label>
-    <div class="line-grid">
-      <label class="inline-check"><input type="checkbox" data-field="contains_ae_target" ${line.contains_ae_target ? "checked" : ""} disabled> contains_ae_target (auto)</label>
-      <label class="inline-check"><input type="checkbox" data-field="contains_marker" ${line.contains_marker ? "checked" : ""}> contains_marker</label>
-      <label class="inline-check"><input type="checkbox" data-field="uncertain_ae" ${line.uncertain_ae ? "checked" : ""}> uncertain_ae</label>
-      <label class="inline-check"><input type="checkbox" data-field="marker_uncertain" ${line.marker_uncertain ? "checked" : ""}> marker_uncertain</label>
-      <label>glyphs_auto <input class="glyph-summary" type="text" value="${safeGlyphSummary}" readonly></label>
-      ${markerIdControl}
-      <label>marker_link_target <input class="marker-field" type="text" data-field="marker_link_target" value="${safeMarkerTarget}"></label>
-      <label>reviewer <input type="text" data-field="reviewer" value="${safeReviewer}" readonly></label>
-      <label>review_status
-        <select data-field="review_status">
-          <option value="draft" ${line.review_status === "draft" ? "selected" : ""}>draft</option>
-          <option value="reviewed" ${line.review_status === "reviewed" ? "selected" : ""}>reviewed</option>
-          <option value="locked" ${line.review_status === "locked" ? "selected" : ""}>locked</option>
-        </select>
-      </label>
-    </div>
-    <label>notes
-      <input class="notes-field" type="text" data-field="notes" value="${safeNotes}">
-    </label>
+    <textarea class="text-gold" data-field="text_gold" rows="1">${safeText}</textarea>
+    <input class="notes-field" type="text" data-field="notes" placeholder="notes" value="${safeNotes}">
   `;
 
-  card.querySelectorAll("[data-field]").forEach((el) => {
-    el.addEventListener("input", () => {
-      const field = el.dataset.field;
-      if (el.type === "checkbox") {
-        line[field] = el.checked;
-      } else {
-        line[field] = el.value;
-      }
-      if (field === "marker_id") {
-        line.marker_id = normalizeMarkerIdForRegion(line.marker_id, regionName);
-        if (el.value !== line.marker_id) {
-          el.value = line.marker_id;
-        }
-      }
-      if (field === "text_gold") {
-        refreshDerivedLineFields(line, card);
-      }
-    });
-    el.addEventListener("change", () => {
-      const field = el.dataset.field;
-      if (el.type === "checkbox") {
-        line[field] = el.checked;
-      } else {
-        line[field] = el.value;
-      }
-      if (field === "marker_id") {
-        line.marker_id = normalizeMarkerIdForRegion(line.marker_id, regionName);
-        if (el.value !== line.marker_id) {
-          el.value = line.marker_id;
-        }
-      }
-      if (field === "text_gold") {
-        refreshDerivedLineFields(line, card);
-      }
-    });
-  });
-
+  bindLineFieldEvents(card, line);
   bindFocusTracking(card);
 
   if (options.showRemove) {
-    const removeBtn = card.querySelector(".line-remove-btn");
-    if (removeBtn) {
-      removeBtn.addEventListener("click", () => {
-        options.onRemove?.(idx);
-      });
-    }
+    card.querySelector(".line-remove-btn").addEventListener("click", () => options.onRemove?.());
+  }
+  return card;
+}
+
+function buildBodyLineCard(line, idx, options = {}) {
+  const card = document.createElement("div");
+  card.className = "line-card line-card-body";
+  card.dataset.lineId = line.line_id || "";
+
+  const safeId = escapeHtml(line.line_id || `body_${idx + 1}`);
+  const safeText = escapeHtml(line.text_gold || "");
+  const safeNotes = escapeHtml(line.notes || "");
+  const reviewOpts = REVIEW_STATUSES.map(
+    (s) => `<option value="${s}" ${line.review_status === s ? "selected" : ""}>${s}</option>`
+  ).join("");
+
+  card.innerHTML = `
+    <div class="line-head">
+      <span class="line-id">${safeId}</span>
+      <div class="line-head-right">
+        <button type="button" class="add-marker-btn" title="Insert footnote marker at end of this line">+ Footnote here</button>
+        <select class="review-status-chip" data-field="review_status">${reviewOpts}</select>
+        ${options.showRemove ? '<button type="button" class="line-remove-btn">Remove</button>' : ""}
+      </div>
+    </div>
+    <textarea class="text-gold" data-field="text_gold" rows="1">${safeText}</textarea>
+    <div class="body-markers-preview"></div>
+    <input class="notes-field" type="text" data-field="notes" placeholder="notes" value="${safeNotes}">
+  `;
+
+  bindLineFieldEvents(card, line);
+  bindFocusTracking(card);
+
+  // Render marker badges (live preview, derived from line.markers).
+  const preview = card.querySelector(".body-markers-preview");
+  const renderMarkers = () => {
+    const fnByNumber = (n) => (currentPayload.footnotes || []).find((fn) => fn.marker_number === n);
+    preview.innerHTML = (line.markers || [])
+      .slice()
+      .sort((a, b) => a.number - b.number)
+      .map((m) => {
+        const fn = fnByNumber(m.number);
+        const snippet = fn ? escapeHtml((fn.text_gold || "").slice(0, 60)) : "";
+        return `<sup class="marker-badge" data-fn-id="${escapeHtml(m.footnote_id)}" title="${snippet}">${m.number}</sup>`;
+      })
+      .join(" ");
+  };
+  renderMarkers();
+
+  card.querySelector(".add-marker-btn").addEventListener("click", () => {
+    addFootnoteAnchored(line.line_id);
+  });
+
+  if (options.showRemove) {
+    card.querySelector(".line-remove-btn").addEventListener("click", () => options.onRemove?.());
   }
 
   return card;
 }
 
-function renderRegion(container, regionName, lines, options = {}) {
-  container.innerHTML = "";
-  (lines || []).forEach((line, idx) => {
-    container.appendChild(buildLineCard(line, idx, regionName, options));
+function bindLineFieldEvents(card, line) {
+  card.querySelectorAll("[data-field]").forEach((el) => {
+    const handler = () => {
+      const field = el.dataset.field;
+      line[field] = el.type === "checkbox" ? el.checked : el.value;
+    };
+    el.addEventListener("input", handler);
+    el.addEventListener("change", handler);
   });
 }
 
-function renderAllRegions() {
+// ---------------------------------------------------------------------------
+// Marginalia block (Option C: stacked fragments visually grouped)
+// ---------------------------------------------------------------------------
+function buildMarginaliaBlock(marginaliaList) {
+  const block = document.createElement("div");
+  block.className = "marginalia-block";
+  marginaliaList.forEach((line) => {
+    block.appendChild(buildMarginaliaCard(line));
+  });
+  return block;
+}
+
+function buildMarginaliaCard(line) {
+  const card = document.createElement("div");
+  card.className = "line-card line-card-marginalia";
+  card.dataset.lineId = line.line_id || "";
+
+  const safeId = escapeHtml(line.line_id || "marg");
+  const safeText = escapeHtml(line.text_gold || "");
+  const safeNotes = escapeHtml(line.notes || "");
+  const safeMarker = escapeHtml(line.marker_id || "");
+
+  // Anchor dropdown: list all body line_ids on the page + an "(unanchored)" option.
+  const bodyLines = currentPayload?.regions?.body || [];
+  const currentTarget = resolveMarginaliaAnchor(line);
+  const anchorOpts = ['<option value="">(unanchored)</option>']
+    .concat(
+      bodyLines.map(
+        (b) =>
+          `<option value="${escapeHtml(b.line_id)}" ${b.line_id === currentTarget ? "selected" : ""}>${escapeHtml(b.line_id)}</option>`
+      )
+    )
+    .join("");
+
+  card.innerHTML = `
+    <div class="line-head">
+      <span class="line-id">${safeId}</span>
+      <div class="line-head-right">
+        <input class="marker-id-mini" type="text" data-field="marker_id" placeholder="m" value="${safeMarker}">
+      </div>
+    </div>
+    <textarea class="text-gold" data-field="text_gold" rows="1">${safeText}</textarea>
+    <div class="line-row">
+      <label class="anchor-row">Anchor
+        <select class="anchor-select">${anchorOpts}</select>
+      </label>
+      <input class="notes-field" type="text" data-field="notes" placeholder="notes" value="${safeNotes}">
+    </div>
+  `;
+
+  bindLineFieldEvents(card, line);
+  bindFocusTracking(card);
+
+  card.querySelector(".anchor-select").addEventListener("change", (event) => {
+    const newTarget = event.target.value || null;
+    setMarginaliaAnchor(line, newTarget);
+    renderAll();
+  });
+  return card;
+}
+
+function resolveMarginaliaAnchor(marginaliaLine) {
+  // Look for a footnote whose source_marginalia_line_ids contains this line.
+  const fns = currentPayload?.footnotes || [];
+  const fn = fns.find((f) =>
+    Array.isArray(f.source_marginalia_line_ids) &&
+    f.source_marginalia_line_ids.includes(marginaliaLine.line_id)
+  );
+  return fn ? fn.body_line_id || "" : "";
+}
+
+function setMarginaliaAnchor(marginaliaLine, newBodyLineId) {
+  // Move this marginalia line out of any existing footnote and into either an
+  // existing footnote anchored to newBodyLineId (if exactly one) or a new one.
+  // Then renumber. Keeps things simple — full split/merge UI is a follow-up.
+  const fns = currentPayload.footnotes || (currentPayload.footnotes = []);
+  // Remove from current footnote.
+  fns.forEach((fn) => {
+    if (Array.isArray(fn.source_marginalia_line_ids)) {
+      fn.source_marginalia_line_ids = fn.source_marginalia_line_ids.filter(
+        (id) => id !== marginaliaLine.line_id
+      );
+    }
+  });
+  // Drop empty footnotes.
+  for (let i = fns.length - 1; i >= 0; i--) {
+    const fn = fns[i];
+    if (
+      (!fn.source_marginalia_line_ids || fn.source_marginalia_line_ids.length === 0) &&
+      fn.source_region === "marginalia" &&
+      !fn.text_gold
+    ) {
+      fns.splice(i, 1);
+    }
+  }
+  if (newBodyLineId) {
+    // Find an existing footnote on this body line, or create a new one.
+    let target = fns.find((fn) => fn.body_line_id === newBodyLineId);
+    if (!target) {
+      target = {
+        footnote_id: nextFootnoteId(currentPayload.page_id, fns),
+        page_id: currentPayload.page_id,
+        marker_number: 0,
+        body_line_id: newBodyLineId,
+        text_gold: marginaliaLine.text_gold || "",
+        text_ocr_original: marginaliaLine.text_ocr_original || marginaliaLine.text_gold || "",
+        kind: "citation",
+        source_region: "marginalia",
+        source_marginalia_line_ids: [],
+        review_status: "draft",
+        notes: "",
+      };
+      fns.push(target);
+    }
+    if (!target.source_marginalia_line_ids.includes(marginaliaLine.line_id)) {
+      target.source_marginalia_line_ids.push(marginaliaLine.line_id);
+    }
+  }
+  renumberFootnotes();
+}
+
+// ---------------------------------------------------------------------------
+// Footnote cards
+// ---------------------------------------------------------------------------
+function buildFootnoteCard(fn) {
+  const card = document.createElement("div");
+  card.className = "footnote-card";
+  card.dataset.footnoteId = fn.footnote_id || "";
+
+  const safeId = escapeHtml(fn.footnote_id || "");
+  const safeText = escapeHtml(fn.text_gold || "");
+  const safeNotes = escapeHtml(fn.notes || "");
+  const safeAnchor = escapeHtml(fn.body_line_id || "(unanchored)");
+  const kindOpts = FOOTNOTE_KINDS.map(
+    (k) => `<option value="${k}" ${fn.kind === k ? "selected" : ""}>${k}</option>`
+  ).join("");
+  const reviewOpts = REVIEW_STATUSES.map(
+    (s) => `<option value="${s}" ${fn.review_status === s ? "selected" : ""}>${s}</option>`
+  ).join("");
+
+  const bodyLines = currentPayload?.regions?.body || [];
+  const anchorOpts = ['<option value="">(unanchored)</option>']
+    .concat(
+      bodyLines.map(
+        (b) =>
+          `<option value="${escapeHtml(b.line_id)}" ${b.line_id === fn.body_line_id ? "selected" : ""}>${escapeHtml(b.line_id)}</option>`
+      )
+    )
+    .join("");
+
+  card.innerHTML = `
+    <div class="footnote-head">
+      <sup class="footnote-marker-badge">${fn.marker_number || "?"}</sup>
+      <span class="footnote-id">${safeId}</span>
+      <span class="footnote-anchor">→ ${safeAnchor}</span>
+      <select class="footnote-kind" data-field="kind">${kindOpts}</select>
+      <select class="review-status-chip" data-field="review_status">${reviewOpts}</select>
+      <button type="button" class="footnote-remove-btn">Delete</button>
+    </div>
+    <textarea class="text-gold" data-field="text_gold" rows="1">${safeText}</textarea>
+    <div class="line-row">
+      <label class="anchor-row">Anchor
+        <select class="anchor-select">${anchorOpts}</select>
+      </label>
+      <input class="notes-field" type="text" data-field="notes" placeholder="notes" value="${safeNotes}">
+    </div>
+  `;
+
+  card.querySelectorAll("[data-field]").forEach((el) => {
+    const handler = () => {
+      const field = el.dataset.field;
+      fn[field] = el.type === "checkbox" ? el.checked : el.value;
+    };
+    el.addEventListener("input", handler);
+    el.addEventListener("change", handler);
+  });
+  bindFocusTracking(card);
+
+  card.querySelector(".anchor-select").addEventListener("change", (event) => {
+    fn.body_line_id = event.target.value || "";
+    renumberFootnotes();
+    renderAll();
+  });
+
+  card.querySelector(".footnote-remove-btn").addEventListener("click", () => {
+    const fns = currentPayload.footnotes || [];
+    const idx = fns.indexOf(fn);
+    if (idx >= 0) fns.splice(idx, 1);
+    renumberFootnotes();
+    renderAll();
+  });
+
+  return card;
+}
+
+function addFootnoteAnchored(bodyLineId) {
   if (!currentPayload) return;
-
-  renderRegion(headerTable, "header", currentPayload.regions?.header || [], {
-    showRemove: true,
-    onRemove: (idx) => {
-      currentPayload.regions.header.splice(idx, 1);
-      renumberRegionLines("header");
-      renderAllRegions();
-    },
+  const fns = currentPayload.footnotes || (currentPayload.footnotes = []);
+  fns.push({
+    footnote_id: nextFootnoteId(currentPayload.page_id, fns),
+    page_id: currentPayload.page_id,
+    marker_number: 0,
+    body_line_id: bodyLineId || "",
+    text_gold: "",
+    text_ocr_original: "",
+    kind: "citation",
+    source_region: "manual",
+    source_marginalia_line_ids: [],
+    review_status: "draft",
+    notes: "",
   });
+  renumberFootnotes();
+  renderAll();
+}
 
-  renderRegion(bodyTable, "body", currentPayload.regions?.body || [], {
-    showRemove: true,
-    onRemove: (idx) => {
-      currentPayload.regions.body.splice(idx, 1);
-      renumberRegionLines("body");
-      renderAllRegions();
-    },
-  });
-
-  renderRegion(footnoteTable, "footnote", currentPayload.regions?.footnote || [], {
-    showRemove: true,
-    onRemove: (idx) => {
-      const removed = currentPayload.regions.footnote[idx];
-      const removedId = removed?.line_id ? [String(removed.line_id)] : [];
-      currentPayload.regions.footnote.splice(idx, 1);
-      renumberRegionLines("footnote", removedId);
-      renderAllRegions();
-    },
+// ---------------------------------------------------------------------------
+// Region renderers
+// ---------------------------------------------------------------------------
+function renderHeader() {
+  headerContainer.innerHTML = "";
+  const lines = currentPayload?.regions?.header || [];
+  lines.forEach((line, idx) => {
+    headerContainer.appendChild(
+      buildLineCardSimple(line, "header", {
+        showRemove: true,
+        onRemove: () => {
+          lines.splice(idx, 1);
+          renderHeader();
+        },
+      })
+    );
   });
 }
 
-function bindMeta(meta) {
-  meta.reviewer = DEFAULT_REVIEWER;
+function renderBodyWithMarginalia() {
+  bodyContainer.innerHTML = "";
+  unanchoredMarginaliaContainer.innerHTML = "";
+
+  const bodyLines = currentPayload?.regions?.body || [];
+  const marginaliaLines = currentPayload?.regions?.marginalia || [];
+
+  // Group marginalia by anchored body_line_id (resolved via footnotes).
+  const bodyToMarginalia = new Map();
+  const unanchored = [];
+  marginaliaLines.forEach((line) => {
+    const anchor = resolveMarginaliaAnchor(line);
+    if (anchor) {
+      if (!bodyToMarginalia.has(anchor)) bodyToMarginalia.set(anchor, []);
+      bodyToMarginalia.get(anchor).push(line);
+    } else {
+      unanchored.push(line);
+    }
+  });
+
+  // Unanchored rail at the top.
+  if (unanchored.length > 0) {
+    const heading = document.createElement("div");
+    heading.className = "unanchored-heading";
+    heading.textContent = `Unanchored marginalia (${unanchored.length})`;
+    unanchoredMarginaliaContainer.appendChild(heading);
+    unanchoredMarginaliaContainer.appendChild(buildMarginaliaBlock(unanchored));
+  }
+
+  // Body rows: each row = body line + its marginalia block.
+  bodyLines.forEach((line, idx) => {
+    const row = document.createElement("div");
+    row.className = "body-row";
+
+    const bodyCell = document.createElement("div");
+    bodyCell.className = "body-cell";
+    bodyCell.appendChild(
+      buildBodyLineCard(line, idx, {
+        showRemove: true,
+        onRemove: () => {
+          bodyLines.splice(idx, 1);
+          renumberFootnotes();
+          renderAll();
+        },
+      })
+    );
+
+    const margCell = document.createElement("div");
+    margCell.className = "marg-cell";
+    const margForLine = bodyToMarginalia.get(line.line_id) || [];
+    if (margForLine.length > 0) {
+      margCell.appendChild(buildMarginaliaBlock(margForLine));
+    }
+
+    row.appendChild(bodyCell);
+    row.appendChild(margCell);
+    bodyContainer.appendChild(row);
+  });
+}
+
+function renderFootnotes() {
+  footnoteContainer.innerHTML = "";
+  const fns = currentPayload?.footnotes || [];
+  if (fns.length === 0) {
+    const empty = document.createElement("div");
+    empty.className = "footnote-empty";
+    empty.textContent = "No footnotes yet. Use \u201c+ Footnote here\u201d on a body line, or anchor a marginalia.";
+    footnoteContainer.appendChild(empty);
+    return;
+  }
+  fns.forEach((fn) => footnoteContainer.appendChild(buildFootnoteCard(fn)));
+}
+
+function renderCatchword() {
+  catchwordContainer.innerHTML = "";
+  const lines = currentPayload?.regions?.catchword || [];
+  lines.forEach((line, idx) => {
+    catchwordContainer.appendChild(
+      buildLineCardSimple(line, "catchword", {
+        showRemove: true,
+        onRemove: () => {
+          lines.splice(idx, 1);
+          renderCatchword();
+        },
+      })
+    );
+  });
+}
+
+function renderAll() {
+  if (!currentPayload) return;
+  renderHeader();
+  renderBodyWithMarginalia();
+  renderFootnotes();
+  renderCatchword();
+}
+
+// ---------------------------------------------------------------------------
+// Page meta binding
+// ---------------------------------------------------------------------------
+function bindMeta(payload) {
+  const meta = payload.meta || (payload.meta = {});
+  metaPageNum.value = String(payload.page_num || "");
+  metaSourcePdf.value = String(payload.source_pdf || "");
   metaReviewer.value = DEFAULT_REVIEWER;
-  metaAnnotationStatus.value = meta.annotation_status || "draft";
+  metaAnnotationStatus.value = meta.annotation_status || "";
   metaReviewStatus.value = meta.review_status || "draft";
   metaNotes.value = meta.notes || "";
+  metaOcrPageSummary.value = meta.ocr_page_summary || "";
 
-  metaReviewer.oninput = () => {
-    meta.reviewer = DEFAULT_REVIEWER;
-    metaReviewer.value = DEFAULT_REVIEWER;
+  metaOcrEngine.textContent = meta.ocr_engine || "\u2014";
+  metaOcrModel.textContent = meta.ocr_provider_model || "\u2014";
+  metaOcrLang.textContent = (meta.ocr_lang || []).join(", ") || "\u2014";
+
+  metaPageNum.oninput = () => {
+    const v = parseInt(metaPageNum.value, 10);
+    payload.page_num = Number.isFinite(v) ? v : payload.page_num;
   };
+  metaSourcePdf.oninput = () => { payload.source_pdf = metaSourcePdf.value; };
   metaAnnotationStatus.oninput = () => { meta.annotation_status = metaAnnotationStatus.value; };
   metaReviewStatus.onchange = () => { meta.review_status = metaReviewStatus.value; };
   metaNotes.oninput = () => { meta.notes = metaNotes.value; };
+  metaOcrPageSummary.oninput = () => { meta.ocr_page_summary = metaOcrPageSummary.value; };
 }
 
+// ---------------------------------------------------------------------------
+// Load / Save
+// ---------------------------------------------------------------------------
 async function loadPage(pageId) {
   try {
     setStatus("Loading...");
     const res = await fetch(`/api/page/${pageId}`);
-    if (!res.ok) {
-      throw new Error(`Load failed: ${res.status}`);
-    }
+    if (!res.ok) throw new Error(`Load failed: ${res.status}`);
     currentPayload = await res.json();
-    currentPayload.regions = currentPayload.regions || {};
-    normalizeRegionLines("header");
-    normalizeRegionLines("body");
-    normalizeRegionLines("footnote");
+    normalizePayload(currentPayload);
     applyDefaultReviewer(currentPayload);
-    bindMeta(currentPayload.meta || (currentPayload.meta = {}));
-    renderAllRegions();
+    renumberFootnotes();
+    bindMeta(currentPayload);
+    renderAll();
 
-    const parsedPageNum = Number(currentPayload.page_num);
-    const fallbackPageNum = Number(String(pageId || "").replace(/^p/, ""));
-    const pdfPageNum = Number.isFinite(parsedPageNum) && parsedPageNum > 0
-      ? parsedPageNum
-      : (Number.isFinite(fallbackPageNum) && fallbackPageNum > 0 ? fallbackPageNum : 1);
+    const parsed = Number(currentPayload.page_num);
+    const fallback = Number(String(pageId || "").replace(/^p/, ""));
+    const pdfPageNum = Number.isFinite(parsed) && parsed > 0 ? parsed
+      : (Number.isFinite(fallback) && fallback > 0 ? fallback : 1);
 
     const sourcePdfKey = String(currentPayload.source_pdf || "");
     if (!pdfFrame.src || currentPdfSource !== sourcePdfKey) {
-      // New source PDF: load dedicated PDF.js viewer at target page.
       currentPdfSource = sourcePdfKey;
       pdfFrame.src = `/pdfjs/${pageId}?page=${pdfPageNum}#page=${pdfPageNum}`;
     } else {
-      // Same source PDF: keep viewer loaded and instruct it to switch pages.
       pdfFrame.contentWindow?.postMessage({ type: "setPage", page: pdfPageNum }, window.location.origin);
     }
+    updatePdfPaneHeader(sourcePdfKey, pdfPageNum);
     setStatus(`Loaded ${pageId}`);
   } catch (err) {
     setStatus(String(err), true);
@@ -555,7 +805,8 @@ async function savePage() {
     if (data.meta && currentPayload?.meta) {
       currentPayload.meta = { ...currentPayload.meta, ...data.meta };
     }
-    setStatus(`Saved ${pageId}`);
+    const editsCount = data.edits_recorded ?? 0;
+    setStatus(`Saved ${pageId} (${editsCount} edits logged)`);
   } catch (err) {
     setStatus(String(err), true);
   }
@@ -566,32 +817,45 @@ saveBtn.addEventListener("click", savePage);
 
 addHeaderBtn.addEventListener("click", () => {
   if (!currentPayload) return;
-  const nextOrdinal = getNextOrdinal("header");
-  currentPayload.regions.header.push(createEmptyLine(currentPayload.page_id || pageSelect.value, "header", nextOrdinal));
-  renumberRegionLines("header");
-  renderAllRegions();
+  const ord = getNextOrdinal("header");
+  currentPayload.regions.header.push(
+    createEmptyLine(currentPayload.page_id || pageSelect.value, "header", ord)
+  );
+  renderHeader();
 });
 
-addFootnoteBtn.addEventListener("click", () => {
+addBodyBtn.addEventListener("click", () => {
   if (!currentPayload) return;
-  const nextOrdinal = getNextOrdinal("footnote");
-  currentPayload.regions.footnote.push(createEmptyLine(currentPayload.page_id || pageSelect.value, "footnote", nextOrdinal));
-  renumberRegionLines("footnote");
-  renderAllRegions();
+  const ord = getNextOrdinal("body");
+  currentPayload.regions.body.push(
+    createEmptyLine(currentPayload.page_id || pageSelect.value, "body", ord)
+  );
+  renderBodyWithMarginalia();
 });
 
+addFootnoteBtn.addEventListener("click", () => addFootnoteAnchored(""));
+
+addCatchwordBtn.addEventListener("click", () => {
+  if (!currentPayload) return;
+  const ord = getNextOrdinal("catchword");
+  currentPayload.regions.catchword.push(
+    createEmptyLine(currentPayload.page_id || pageSelect.value, "catchword", ord)
+  );
+  renderCatchword();
+});
+
+// ---------------------------------------------------------------------------
+// Glyph bar / superscripts
+// ---------------------------------------------------------------------------
 glyphBar.querySelectorAll("button[data-glyph]").forEach((btn) => {
   btn.addEventListener("click", () => insertGlyph(btn.dataset.glyph));
 });
-
 if (insertSuperscriptRawBtn) {
   insertSuperscriptRawBtn.addEventListener("click", () => insertCustomSuperscript(true));
 }
-
 if (insertSuperscriptBtn) {
   insertSuperscriptBtn.addEventListener("click", () => insertCustomSuperscript(false));
 }
-
 if (superscriptInput) {
   superscriptInput.addEventListener("keydown", (event) => {
     if (event.key === "Enter") {
@@ -607,33 +871,12 @@ document.addEventListener("keydown", (event) => {
     savePage();
     return;
   }
-
   if (!event.altKey) return;
-
-  if (event.key === "e" && !event.shiftKey) {
+  const k = event.key;
+  const map = { e: "æ", E: "Æ", o: "œ", O: "Œ", "6": "Ↄ", "7": "ↄ", d: "ᵈ", n: "ⁿ" };
+  if (map[k]) {
     event.preventDefault();
-    insertGlyph("æ");
-  } else if (event.key === "E" || (event.key === "e" && event.shiftKey)) {
-    event.preventDefault();
-    insertGlyph("Æ");
-  } else if (event.key === "o" && !event.shiftKey) {
-    event.preventDefault();
-    insertGlyph("œ");
-  } else if (event.key === "O" || (event.key === "o" && event.shiftKey)) {
-    event.preventDefault();
-    insertGlyph("Œ");
-  } else if (event.key === "6") {
-    event.preventDefault();
-    insertGlyph("Ↄ");
-  } else if (event.key === "7") {
-    event.preventDefault();
-    insertGlyph("ↄ");
-  } else if (event.key.toLowerCase() === "d") {
-    event.preventDefault();
-    insertGlyph("ᵈ");
-  } else if (event.key.toLowerCase() === "n") {
-    event.preventDefault();
-    insertGlyph("ⁿ");
+    insertGlyph(map[k]);
   }
 });
 
@@ -643,10 +886,8 @@ if (window.__PAGES__ && window.__PAGES__.length > 0) {
 }
 
 // ---------------------------------------------------------------------------
-// OCR-from-UI controls: pick a source PDF and page, run Gemini in the
-// background, poll for completion, then auto-load the new annotation.
+// OCR-from-UI controls
 // ---------------------------------------------------------------------------
-
 const ocrPdfSelect = document.getElementById("ocrPdfSelect");
 const ocrPageInput = document.getElementById("ocrPageInput");
 const ocrPartSelect = document.getElementById("ocrPartSelect");
@@ -690,18 +931,12 @@ async function pollOcrJob(jobId, pageId) {
   while (true) {
     await new Promise((r) => setTimeout(r, 4000));
     const res = await fetch(`/api/ocr/status/${jobId}`);
-    if (!res.ok) {
-      throw new Error(`status fetch failed: ${res.status}`);
-    }
+    if (!res.ok) throw new Error(`status fetch failed: ${res.status}`);
     const job = await res.json();
     const elapsed = Math.round((Date.now() - start) / 1000);
     setOcrStatus(`${job.state} (${elapsed}s): ${job.message || ""}`);
-    if (job.state === "done") {
-      return job;
-    }
-    if (job.state === "error") {
-      throw new Error(job.message || "OCR job failed");
-    }
+    if (job.state === "done") return job;
+    if (job.state === "error") throw new Error(job.message || "OCR job failed");
   }
 }
 
@@ -709,14 +944,8 @@ async function runOcr(forceOverwrite) {
   const pdf = ocrPdfSelect?.value;
   const page = parseInt(ocrPageInput?.value || "0", 10);
   const part = ocrPartSelect?.value || "part1";
-  if (!pdf) {
-    setOcrStatus("Pick a PDF first.", true);
-    return;
-  }
-  if (!Number.isFinite(page) || page < 1) {
-    setOcrStatus("Page must be a positive integer.", true);
-    return;
-  }
+  if (!pdf) { setOcrStatus("Pick a PDF first.", true); return; }
+  if (!Number.isFinite(page) || page < 1) { setOcrStatus("Page must be a positive integer.", true); return; }
 
   ocrRunBtn.disabled = true;
   setOcrStatus("Starting...");
@@ -724,45 +953,29 @@ async function runOcr(forceOverwrite) {
     const res = await fetch("/api/ocr/start", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        pdf,
-        page,
-        part,
-        overwrite: !!(forceOverwrite || ocrOverwrite?.checked),
-      }),
+      body: JSON.stringify({ pdf, page, part, overwrite: !!(forceOverwrite || ocrOverwrite?.checked) }),
     });
     const data = await res.json().catch(() => ({}));
-
     if (res.status === 409 && data.error === "annotation_exists") {
-      const proceed = window.confirm(
-        `${data.message}\n\nOverwrite the existing annotation?`
-      );
-      if (!proceed) {
-        setOcrStatus("Cancelled (existing annotation kept).");
-        return;
-      }
+      const proceed = window.confirm(`${data.message}\n\nOverwrite the existing annotation?`);
+      if (!proceed) { setOcrStatus("Cancelled."); return; }
       ocrRunBtn.disabled = false;
       return runOcr(true);
     }
-
-    if (!res.ok || !data.ok) {
-      throw new Error(data.error || data.message || `HTTP ${res.status}`);
-    }
+    if (!res.ok || !data.ok) throw new Error(data.error || data.message || `HTTP ${res.status}`);
 
     const { job_id: jobId, page_id: pageId } = data;
     setOcrStatus(`Queued (${pageId})`);
     const finalJob = await pollOcrJob(jobId, pageId);
     setOcrStatus(`Done: ${finalJob.message || pageId}`);
 
-    // Refresh page selector and load the new page.
     const pagesRes = await fetch("/api/pages");
     const pagesData = await pagesRes.json();
     const pages = pagesData.pages || [];
     pageSelect.innerHTML = "";
     for (const p of pages) {
       const opt = document.createElement("option");
-      opt.value = p;
-      opt.textContent = p;
+      opt.value = p; opt.textContent = p;
       pageSelect.appendChild(opt);
     }
     if (pages.includes(pageId)) {
@@ -778,5 +991,30 @@ async function runOcr(forceOverwrite) {
 
 if (ocrRunBtn) {
   ocrRunBtn.addEventListener("click", () => runOcr(false));
-  loadSourcePdfList();
+  loadSourcePdfList().then(previewOcrSelection);
+}
+
+function previewOcrSelection() {
+  if (!ocrPdfSelect || !pdfFrame) return;
+  const pdfName = String(ocrPdfSelect.value || "").trim();
+  if (!pdfName) return;
+  const page = parseInt(ocrPageInput?.value || "1", 10);
+  const safePage = Number.isFinite(page) && page > 0 ? page : 1;
+  const previewKey = `source-pdf:${pdfName}`;
+  if (currentPdfSource !== previewKey) {
+    currentPdfSource = previewKey;
+    pdfFrame.src = `/pdfjs-source?pdf=${encodeURIComponent(pdfName)}&page=${safePage}#page=${safePage}`;
+  } else {
+    pdfFrame.contentWindow?.postMessage({ type: "setPage", page: safePage }, window.location.origin);
+  }
+  updatePdfPaneHeader(pdfName, safePage);
+}
+
+if (ocrPdfSelect) ocrPdfSelect.addEventListener("change", previewOcrSelection);
+if (ocrPageInput) {
+  ocrPageInput.addEventListener("change", previewOcrSelection);
+  ocrPageInput.addEventListener("input", () => {
+    clearTimeout(ocrPageInput._previewTimer);
+    ocrPageInput._previewTimer = setTimeout(previewOcrSelection, 300);
+  });
 }

--- a/08_working_scratch/phase3b/ui/templates/annotation_ui.html
+++ b/08_working_scratch/phase3b/ui/templates/annotation_ui.html
@@ -59,40 +59,89 @@
 
   <main class="layout">
     <section class="editor-pane">
-      <h2>Page metadata</h2>
-      <div class="meta-grid">
-        <label>Reviewer <input id="metaReviewer" type="text" readonly></label>
-        <label>Annotation status <input id="metaAnnotationStatus" type="text"></label>
-        <label>Review status
-          <select id="metaReviewStatus">
-            <option value="draft">draft</option>
-            <option value="reviewed">reviewed</option>
-            <option value="locked">locked</option>
-          </select>
+      <section class="meta-card">
+        <h2>Page metadata</h2>
+        <div class="meta-grid">
+          <label>Page #
+            <input id="metaPageNum" type="number" min="1">
+          </label>
+          <label>Source PDF
+            <input id="metaSourcePdf" type="text">
+          </label>
+          <label>Annotation status
+            <input id="metaAnnotationStatus" type="text">
+          </label>
+          <label>Review status
+            <select id="metaReviewStatus">
+              <option value="draft">draft</option>
+              <option value="reviewed">reviewed</option>
+              <option value="locked">locked</option>
+            </select>
+          </label>
+          <label>Reviewer
+            <input id="metaReviewer" type="text" readonly>
+          </label>
+        </div>
+        <label>OCR page summary
+          <textarea id="metaOcrPageSummary" rows="2"></textarea>
         </label>
-      </div>
-      <label>Notes
-        <textarea id="metaNotes" rows="2"></textarea>
-      </label>
+        <label>Notes
+          <textarea id="metaNotes" rows="2"></textarea>
+        </label>
+        <div class="meta-provenance">
+          <span class="meta-prov-label">Engine</span>
+          <span id="metaOcrEngine" class="meta-prov-value">&mdash;</span>
+          <span class="meta-prov-label">Model</span>
+          <span id="metaOcrModel" class="meta-prov-value">&mdash;</span>
+          <span class="meta-prov-label">Lang</span>
+          <span id="metaOcrLang" class="meta-prov-value">&mdash;</span>
+        </div>
+      </section>
 
-      <div class="section-head">
-        <h2>Header lines</h2>
-        <button id="addHeaderBtn" type="button" class="small-btn">+ Header line</button>
-      </div>
-      <div id="headerTable"></div>
+      <section class="region-section" id="headerSection">
+        <div class="section-head">
+          <h2>Header</h2>
+          <button id="addHeaderBtn" type="button" class="small-btn">+ Header line</button>
+        </div>
+        <div id="headerContainer"></div>
+      </section>
 
-      <h2>Body lines</h2>
-      <div id="bodyTable"></div>
+      <section class="region-section" id="bodySection">
+        <div class="section-head">
+          <h2>Body &amp; Marginalia</h2>
+          <button id="addBodyBtn" type="button" class="small-btn">+ Body line</button>
+        </div>
+        <div id="unanchoredMarginaliaContainer" class="unanchored-marginalia"></div>
+        <div id="bodyContainer" class="body-grid"></div>
+      </section>
 
-      <div class="section-head">
-        <h2>Footnote lines</h2>
-        <button id="addFootnoteBtn" type="button" class="small-btn">+ Footnote line</button>
-      </div>
-      <div id="footnoteTable"></div>
+      <section class="region-section" id="footnoteSection">
+        <div class="section-head">
+          <h2>Footnotes</h2>
+          <button id="addFootnoteBtn" type="button" class="small-btn">+ Footnote</button>
+        </div>
+        <div id="footnoteContainer"></div>
+      </section>
+
+      <section class="region-section" id="catchwordSection">
+        <div class="section-head">
+          <h2>Catchword</h2>
+          <button id="addCatchwordBtn" type="button" class="small-btn">+ Catchword</button>
+        </div>
+        <div id="catchwordContainer"></div>
+      </section>
     </section>
 
     <section class="pdf-pane">
-      <h2>Source PDF</h2>
+      <header class="pdf-pane-header">
+        <h2>Source PDF</h2>
+        <div class="pdf-pane-meta">
+          <span class="pdf-pane-meta-label">File</span>
+          <span id="pdfPaneSourceName" class="pdf-pane-meta-value" title="">&mdash;</span>
+          <span class="pdf-pane-meta-label">Page</span>
+          <span id="pdfPanePageNum" class="pdf-pane-meta-value">&mdash;</span>
+        </div>
+      </header>
       <iframe id="pdfFrame" title="Source PDF"></iframe>
     </section>
   </main>

--- a/08_working_scratch/pipeline_scripts/pilot_to_phase3b.py
+++ b/08_working_scratch/pipeline_scripts/pilot_to_phase3b.py
@@ -2,42 +2,55 @@
 
 The pilot output (``01_raw_ocr_output/<part>/<part>_pilot_ocr.json``) is a
 flat list of pages, each with a ``lines[]`` array spanning every region
-(``header``, ``body``, ``footnote``, ``marginalia``, ``catchword``).
+(``header``, ``body``, ``marginalia``, ``catchword``).
 
 The Phase 3b annotator expects one file per page at
-``08_working_scratch/phase3b/annotations/page_pNNNN.json`` with a
-``regions`` dict. We extend that schema with two new regions so Gemini's
-marginalia and catchword output round-trip cleanly:
+``08_working_scratch/phase3b/annotations/page_pNNNN.json`` shaped roughly
+as follows::
 
     {
+      "page_id": "p0025",
+      "part": "part1",
+      "source_pdf": "00_source_pdf/...pdf",
+      "page_num": 25,
       "regions": {
-        "header": [...],
-        "body": [...],
-        "footnote": [...],
-        "marginalia": [...],   # NEW: each line carries marker_id and
-                               #      anchor_index pointing into body
-        "catchword": [...]     # NEW: typically a single bottom-right token
-      }
+        "header":     [...],
+        "body":       [...],     # body lines carry markers[] of footnote refs
+        "marginalia": [...],     # raw OCR fragments preserved for provenance
+        "catchword":  [...]
+      },
+      "footnotes": [...],        # auto-built from coalesced marginalia
+      "meta": {...}
     }
 
-The Gemini transcription is written into ``text_gold`` directly so the
-annotator can edit-in-place; ``confidence`` and ``illegible`` are
-preserved as ``ocr_confidence`` and ``ocr_illegible`` for QA filtering.
+Each body line whose anchor was used carries a ``markers`` array linking
+into ``footnotes[]`` by ``footnote_id``. Marginalia coalescing groups
+fragments that share an anchor (or attach to adjacent body lines and
+appear to be a single OCR-split note) into one logical footnote.
+
+Legacy Phase-3a æ-research fields (``contains_ae_target``,
+``contains_marker``, ``uncertain_ae``, ``marker_uncertain``,
+``glyph_counts``, ``marker_link_target``) are no longer written. The
+loader in ``annotation_ui.py`` tolerates them on read for older files.
 """
 
 from __future__ import annotations
 
 import argparse
 import json
-import re
 from pathlib import Path
 from typing import Iterable
 
-PHASE3B_REGIONS = ("header", "body", "footnote", "marginalia", "catchword")
+PHASE3B_REGIONS = ("header", "body", "marginalia", "catchword")
+FOOTNOTE_KIND_DEFAULT = "citation"
 
 
 def _line_id(page_id: str, region: str, ordinal: int) -> str:
     return f"{page_id}_{region}_l{ordinal:04d}"
+
+
+def _footnote_id(page_id: str, ordinal: int) -> str:
+    return f"{page_id}_fn_{ordinal:03d}"
 
 
 def _convert_line(
@@ -45,31 +58,18 @@ def _convert_line(
     region: str,
     ordinal: int,
     src: dict,
-    body_anchor_to_lineid: dict[int, str] | None = None,
 ) -> dict:
     text_gold = str(src.get("text_raw_ocr") or src.get("normalized_form") or "")
     marker_id = str(src.get("marker_id") or "")
     anchor = src.get("marginalia_anchor_index")
-    marker_link_target = ""
-    if (
-        region == "marginalia"
-        and isinstance(anchor, int)
-        and body_anchor_to_lineid
-        and anchor in body_anchor_to_lineid
-    ):
-        marker_link_target = body_anchor_to_lineid[anchor]
 
-    return {
+    line: dict = {
         "page_id": page_id,
         "region": region,
         "line_id": _line_id(page_id, region, ordinal),
         "text_gold": text_gold,
-        "contains_ae_target": bool(re.search(r"æ|Æ|ae|AE", text_gold)),
-        "contains_marker": bool(marker_id),
+        "text_ocr_original": text_gold,  # Frozen baseline for diff/edit log.
         "marker_id": marker_id,
-        "marker_link_target": marker_link_target,
-        "uncertain_ae": False,
-        "marker_uncertain": False,
         "reviewer": "",
         "review_status": "draft",
         "notes": "",
@@ -78,6 +78,155 @@ def _convert_line(
         "ocr_illegible": bool(src.get("illegible", False)),
         "ocr_marginalia_anchor_index": anchor,
     }
+    if region == "body":
+        line["markers"] = []  # Populated when footnotes are built.
+    return line
+
+
+def _starts_with_continuation(text: str) -> bool:
+    """Return True if ``text`` looks like an OCR-split continuation."""
+    if not text:
+        return False
+    first = text[0]
+    if first in ("-", "—", "–"):
+        return True
+    # Lowercase first letter (Latin alphabet) suggests mid-word/sentence split.
+    if first.isalpha() and first.islower():
+        return True
+    return False
+
+
+def _coalesce_marginalia_groups(
+    marginalia_lines: list[dict],
+    body_anchor_to_lineid: dict[int, str],
+) -> list[dict]:
+    """Group fragmented marginalia lines into logical notes.
+
+    Same-anchor fragments are always coalesced. Adjacent-anchor fragments are
+    coalesced only when the next fragment looks like a continuation (lowercase
+    or hyphenated start). The returned groups preserve document order.
+    """
+    groups: list[dict] = []
+    current: dict | None = None
+
+    for src in marginalia_lines:
+        anchor = src.get("ocr_marginalia_anchor_index")
+        body_line_id = (
+            body_anchor_to_lineid.get(anchor) if isinstance(anchor, int) else None
+        )
+        text = str(src.get("text_gold") or "")
+
+        if current is None:
+            current = {
+                "anchor": anchor,
+                "body_line_id": body_line_id,
+                "fragments": [src],
+                "text_parts": [text] if text else [],
+            }
+            continue
+
+        same_anchor = (
+            isinstance(anchor, int)
+            and isinstance(current["anchor"], int)
+            and anchor == current["anchor"]
+        )
+        adjacent_anchor = (
+            isinstance(anchor, int)
+            and isinstance(current["anchor"], int)
+            and anchor - current["anchor"] in (0, 1)
+        )
+        is_continuation = adjacent_anchor and _starts_with_continuation(text)
+
+        if same_anchor or is_continuation:
+            current["fragments"].append(src)
+            if text:
+                current["text_parts"].append(text)
+        else:
+            groups.append(current)
+            current = {
+                "anchor": anchor,
+                "body_line_id": body_line_id,
+                "fragments": [src],
+                "text_parts": [text] if text else [],
+            }
+
+    if current is not None:
+        groups.append(current)
+    return groups
+
+
+def _join_fragments(text_parts: list[str]) -> str:
+    """Join fragment texts, repairing OCR end-of-line hyphenation."""
+    if not text_parts:
+        return ""
+    out = text_parts[0]
+    for part in text_parts[1:]:
+        if not part:
+            continue
+        if out.endswith(("-", "—", "–")):
+            out = out[:-1] + part
+        else:
+            out = out + " " + part
+    return out
+
+
+def _build_footnotes(
+    page_id: str,
+    body_lines: list[dict],
+    marginalia_lines: list[dict],
+    body_anchor_to_lineid: dict[int, str],
+) -> list[dict]:
+    """Construct footnotes[] from coalesced marginalia and attach markers[]."""
+    body_id_to_line = {line["line_id"]: line for line in body_lines}
+    body_id_to_index = {line["line_id"]: idx for idx, line in enumerate(body_lines)}
+
+    groups = _coalesce_marginalia_groups(marginalia_lines, body_anchor_to_lineid)
+
+    # Stable ordering: anchored notes by body-line position; orphans last in
+    # the order they appeared. This drives marker_number assignment.
+    orphan_index: dict[int, int] = {id(g): i for i, g in enumerate(groups)}
+
+    def sort_key(group: dict) -> tuple[int, int]:
+        body_line_id = group.get("body_line_id")
+        if body_line_id and body_line_id in body_id_to_index:
+            return (0, body_id_to_index[body_line_id])
+        return (1, orphan_index[id(group)])
+
+    groups_sorted = sorted(groups, key=sort_key)
+
+    footnotes: list[dict] = []
+    for ordinal, group in enumerate(groups_sorted, start=1):
+        text_gold = _join_fragments(group["text_parts"])
+        body_line_id = group.get("body_line_id") or ""
+        fn_id = _footnote_id(page_id, ordinal)
+        source_ids = [frag.get("line_id", "") for frag in group["fragments"]]
+
+        footnotes.append(
+            {
+                "footnote_id": fn_id,
+                "page_id": page_id,
+                "marker_number": ordinal,
+                "body_line_id": body_line_id,
+                "text_gold": text_gold,
+                "text_ocr_original": text_gold,
+                "kind": FOOTNOTE_KIND_DEFAULT,
+                "source_region": "marginalia",
+                "source_marginalia_line_ids": source_ids,
+                "review_status": "draft",
+                "notes": "",
+            }
+        )
+
+        if body_line_id and body_line_id in body_id_to_line:
+            body_id_to_line[body_line_id].setdefault("markers", []).append(
+                {
+                    "number": ordinal,
+                    "footnote_id": fn_id,
+                    "char_offset": None,  # null = render at end of line.
+                }
+            )
+
+    return footnotes
 
 
 def convert_record(record: dict, *, source_pdf: str | None = None) -> dict:
@@ -88,7 +237,7 @@ def convert_record(record: dict, *, source_pdf: str | None = None) -> dict:
 
     raw_lines: list[dict] = list(record.get("lines", []))
 
-    # First pass over body lines so marginalia anchor_index → line_id can map.
+    # First pass over body lines so marginalia anchor_index → body line_id.
     body_anchor_to_lineid: dict[int, str] = {}
     body_ordinal = 0
     for src in raw_lines:
@@ -105,6 +254,11 @@ def convert_record(record: dict, *, source_pdf: str | None = None) -> dict:
 
     for src in raw_lines:
         region = str(src.get("region", "body"))
+        # Pilot OCR output may include a "footnote" region; we no longer emit
+        # one (footnotes are derived from marginalia). Map any incoming
+        # footnote lines into marginalia so the text isn't lost.
+        if region == "footnote":
+            region = "marginalia"
         if region not in regions:
             region = "body"
         region_counters[region] += 1
@@ -114,9 +268,15 @@ def convert_record(record: dict, *, source_pdf: str | None = None) -> dict:
                 region,
                 region_counters[region],
                 src,
-                body_anchor_to_lineid=body_anchor_to_lineid,
             )
         )
+
+    footnotes = _build_footnotes(
+        page_id,
+        regions["body"],
+        regions["marginalia"],
+        body_anchor_to_lineid,
+    )
 
     payload: dict = {
         "page_id": page_id,
@@ -124,6 +284,7 @@ def convert_record(record: dict, *, source_pdf: str | None = None) -> dict:
         "source_pdf": source_pdf or "",
         "page_num": page_num,
         "regions": regions,
+        "footnotes": footnotes,
         "meta": {
             "reviewer": "",
             "annotation_status": "ocr_seeded",

--- a/08_working_scratch/tests/test_annotation_ui_dual_text.py
+++ b/08_working_scratch/tests/test_annotation_ui_dual_text.py
@@ -112,3 +112,213 @@ def test_load_returns_new_dual_text_fields(annotation_app):
     body_line = response.get_json()["regions"]["body"][0]
     assert body_line["text_raw_ocr"] == "Eccleſiarum"
     assert body_line["confidence"] == 0.91
+
+
+# ---------------------------------------------------------------------------
+# Edit log: each /api/page/<page_id> POST appends per-field diff entries to
+# a sidecar JSONL alongside the page JSON. Used downstream for prompt tuning.
+# ---------------------------------------------------------------------------
+
+
+def _build_redesign_payload() -> dict:
+    return {
+        "page_id": "p0099",
+        "part": "part1",
+        "source_pdf": "00_source_pdf/sample.pdf",
+        "page_num": 99,
+        "regions": {
+            "header": [],
+            "body": [
+                {
+                    "page_id": "p0099",
+                    "region": "body",
+                    "line_id": "p0099_body_l0001",
+                    "text_gold": "Body line one.",
+                    "text_ocr_original": "Body line one.",
+                    "marker_id": "",
+                    "review_status": "draft",
+                    "reviewer": "",
+                    "notes": "",
+                    "markers": [
+                        {
+                            "number": 1,
+                            "footnote_id": "p0099_fn_001",
+                            "char_offset": None,
+                        }
+                    ],
+                }
+            ],
+            "marginalia": [],
+            "catchword": [],
+        },
+        "footnotes": [
+            {
+                "footnote_id": "p0099_fn_001",
+                "page_id": "p0099",
+                "marker_number": 1,
+                "body_line_id": "p0099_body_l0001",
+                "text_gold": "Niceph. hist.",
+                "text_ocr_original": "Niceph. hist.",
+                "kind": "citation",
+                "source_region": "marginalia",
+                "source_marginalia_line_ids": [],
+                "review_status": "draft",
+                "notes": "",
+            }
+        ],
+        "meta": {
+            "annotation_status": "ocr_seeded",
+            "review_status": "draft",
+            "reviewer": "",
+            "notes": "",
+            "ocr_page_summary": "summary v1",
+        },
+    }
+
+
+@pytest.fixture
+def redesign_app(tmp_path, monkeypatch):
+    annotations_dir = tmp_path / "annotations"
+    annotations_dir.mkdir()
+    payload = _build_redesign_payload()
+    target = annotations_dir / "page_p0099.json"
+    target.write_text(json.dumps(payload), encoding="utf-8")
+
+    import annotation_ui
+
+    monkeypatch.setattr(annotation_ui, "ANNOTATIONS_DIR", annotations_dir)
+    annotation_ui.app.testing = True
+    yield annotation_ui.app, annotations_dir
+
+
+def _read_edits(annotations_dir: Path) -> list[dict]:
+    path = annotations_dir / "page_p0099.edits.jsonl"
+    if not path.exists():
+        return []
+    return [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines() if line]
+
+
+def test_save_records_line_text_edit_to_sidecar(redesign_app):
+    app, annotations_dir = redesign_app
+    payload = _build_redesign_payload()
+    payload["regions"]["body"][0]["text_gold"] = "Body line one. (edited)"
+
+    client = app.test_client()
+    response = client.post(
+        "/api/page/p0099",
+        data=json.dumps(payload),
+        content_type="application/json",
+    )
+    assert response.status_code == 200
+    assert response.get_json()["edits_recorded"] >= 1
+
+    edits = _read_edits(annotations_dir)
+    line_edits = [e for e in edits if e["scope"] == "line" and e["field"] == "text_gold"]
+    assert len(line_edits) == 1
+    assert line_edits[0]["target_id"] == "p0099_body_l0001"
+    assert line_edits[0]["before"] == "Body line one."
+    assert line_edits[0]["after"] == "Body line one. (edited)"
+
+
+def test_save_records_footnote_edit_and_kind_change(redesign_app):
+    app, annotations_dir = redesign_app
+    payload = _build_redesign_payload()
+    payload["footnotes"][0]["text_gold"] = "Niceph. hist. lib.2."
+    payload["footnotes"][0]["kind"] = "not_a_note"
+
+    client = app.test_client()
+    response = client.post(
+        "/api/page/p0099",
+        data=json.dumps(payload),
+        content_type="application/json",
+    )
+    assert response.status_code == 200
+
+    edits = _read_edits(annotations_dir)
+    fn_edits = [e for e in edits if e["scope"] == "footnote"]
+    fields = {e["field"] for e in fn_edits}
+    assert "text_gold" in fields
+    assert "kind" in fields
+
+
+def test_save_records_page_meta_edit(redesign_app):
+    app, annotations_dir = redesign_app
+    payload = _build_redesign_payload()
+    payload["meta"]["ocr_page_summary"] = "summary v2"
+    payload["meta"]["notes"] = "Reviewed by Paul"
+
+    client = app.test_client()
+    response = client.post(
+        "/api/page/p0099",
+        data=json.dumps(payload),
+        content_type="application/json",
+    )
+    assert response.status_code == 200
+
+    edits = _read_edits(annotations_dir)
+    meta_edits = [e for e in edits if e["scope"] == "page_meta"]
+    fields = {e["field"] for e in meta_edits}
+    assert "ocr_page_summary" in fields
+    assert "notes" in fields
+
+
+def test_edit_log_is_append_only(redesign_app):
+    app, annotations_dir = redesign_app
+    client = app.test_client()
+
+    payload = _build_redesign_payload()
+    payload["regions"]["body"][0]["text_gold"] = "edit 1"
+    client.post("/api/page/p0099", data=json.dumps(payload), content_type="application/json")
+
+    payload2 = _build_redesign_payload()
+    payload2["regions"]["body"][0]["text_gold"] = "edit 2"
+    client.post("/api/page/p0099", data=json.dumps(payload2), content_type="application/json")
+
+    edits = _read_edits(annotations_dir)
+    text_edits = [e for e in edits if e["field"] == "text_gold" and e["scope"] == "line"]
+    # Two saves -> at least two text_gold entries.
+    assert len(text_edits) >= 2
+
+
+def test_legacy_payload_with_old_fields_still_loads_and_saves(redesign_app):
+    """Old payloads with regions.footnote and legacy æ fields still validate."""
+    app, annotations_dir = redesign_app
+    legacy = {
+        "page_id": "p0099",
+        "part": "part1",
+        "source_pdf": "00_source_pdf/sample.pdf",
+        "page_num": 99,
+        "regions": {
+            "header": [],
+            "body": [
+                {
+                    "page_id": "p0099",
+                    "region": "body",
+                    "line_id": "p0099_body_l0001",
+                    "text_gold": "Legacy line",
+                    "contains_ae_target": True,  # legacy
+                    "contains_marker": False,    # legacy
+                    "uncertain_ae": False,       # legacy
+                    "marker_uncertain": False,   # legacy
+                    "marker_id": "",
+                    "marker_link_target": "",    # legacy
+                    "review_status": "draft",
+                    "reviewer": "",
+                    "notes": "",
+                }
+            ],
+            "footnote": [],  # legacy region
+            "marginalia": [],
+            "catchword": [],
+        },
+        "meta": {"annotation_status": "draft", "review_status": "draft", "reviewer": "", "notes": ""},
+    }
+    (annotations_dir / "page_p0099.json").write_text(json.dumps(legacy), encoding="utf-8")
+    client = app.test_client()
+    response = client.post(
+        "/api/page/p0099",
+        data=json.dumps(legacy),
+        content_type="application/json",
+    )
+    assert response.status_code == 200, response.get_data(as_text=True)
+

--- a/08_working_scratch/tests/test_pilot_to_phase3b.py
+++ b/08_working_scratch/tests/test_pilot_to_phase3b.py
@@ -6,7 +6,6 @@ import json
 from pathlib import Path
 import sys
 
-# Make the pipeline scripts directory importable.
 SCRIPTS = Path(__file__).resolve().parents[1] / "pipeline_scripts"
 if str(SCRIPTS) not in sys.path:
     sys.path.insert(0, str(SCRIPTS))
@@ -17,6 +16,8 @@ from pilot_to_phase3b import convert_record, write_phase3b_files
 
 
 def _sample_record() -> dict:
+    """Minimal three-marginalia page exercising both same-anchor and
+    adjacent-anchor coalescing."""
     return {
         "part": "part1",
         "page_num": 1,
@@ -32,7 +33,6 @@ def _sample_record() -> dict:
                 "region": "header",
                 "line_index": 0,
                 "text_raw_ocr": "2",
-                "normalized_form": "2",
                 "confidence": 1.0,
                 "illegible": False,
                 "marker_id": "",
@@ -41,28 +41,73 @@ def _sample_record() -> dict:
             {
                 "region": "body",
                 "line_index": 0,
-                "text_raw_ocr": "First body æ line",
-                "normalized_form": "First body ae line",
+                "text_raw_ocr": "First body line.",
                 "confidence": 0.95,
                 "illegible": False,
                 "marker_id": "",
                 "marginalia_anchor_index": None,
             },
             {
+                "region": "body",
+                "line_index": 1,
+                "text_raw_ocr": "Second body line.",
+                "confidence": 0.95,
+                "illegible": False,
+                "marker_id": "",
+                "marginalia_anchor_index": None,
+            },
+            {
+                "region": "body",
+                "line_index": 2,
+                "text_raw_ocr": "Third body line.",
+                "confidence": 0.95,
+                "illegible": False,
+                "marker_id": "",
+                "marginalia_anchor_index": None,
+            },
+            # Two same-anchor fragments for body line 1 -> coalesce.
+            {
                 "region": "marginalia",
                 "line_index": 0,
-                "text_raw_ocr": "ⁱ Rom. 16. 25.",
-                "normalized_form": "ⁱ Rom. 16. 25.",
+                "text_raw_ocr": "Niceph. hist.",
                 "confidence": 0.9,
                 "illegible": False,
-                "marker_id": "ⁱ",
-                "marginalia_anchor_index": 0,
+                "marker_id": "b",
+                "marginalia_anchor_index": 1,
+            },
+            {
+                "region": "marginalia",
+                "line_index": 1,
+                "text_raw_ocr": "Eccleſiaſt.",
+                "confidence": 0.9,
+                "illegible": False,
+                "marker_id": "",
+                "marginalia_anchor_index": 1,
+            },
+            # Adjacent-anchor continuation (lowercase start) -> coalesce.
+            {
+                "region": "marginalia",
+                "line_index": 2,
+                "text_raw_ocr": "lib.2. cap.40.",
+                "confidence": 0.9,
+                "illegible": False,
+                "marker_id": "",
+                "marginalia_anchor_index": 2,
+            },
+            # Distinct note for body line 2 (capital start, gap to line 0/1).
+            {
+                "region": "marginalia",
+                "line_index": 3,
+                "text_raw_ocr": "Pſal. 19.6.",
+                "confidence": 0.9,
+                "illegible": False,
+                "marker_id": "f",
+                "marginalia_anchor_index": 2,
             },
             {
                 "region": "catchword",
                 "line_index": 0,
                 "text_raw_ocr": "Σαυ-",
-                "normalized_form": "Σαυ-",
                 "confidence": 0.9,
                 "illegible": False,
                 "marker_id": "",
@@ -72,34 +117,79 @@ def _sample_record() -> dict:
     }
 
 
-def test_convert_record_emits_all_five_regions():
+def test_convert_record_emits_four_regions_and_footnotes_array():
     payload = convert_record(_sample_record(), source_pdf="00_source_pdf/x.pdf")
     regions = payload["regions"]
-    assert set(regions.keys()) == {"header", "body", "footnote", "marginalia", "catchword"}
+    assert set(regions.keys()) == {"header", "body", "marginalia", "catchword"}
     assert len(regions["header"]) == 1
-    assert len(regions["body"]) == 1
-    assert len(regions["marginalia"]) == 1
+    assert len(regions["body"]) == 3
+    assert len(regions["marginalia"]) == 4
     assert len(regions["catchword"]) == 1
-    assert regions["footnote"] == []
+    assert "footnote" not in regions
+    assert isinstance(payload["footnotes"], list)
 
 
-def test_marginalia_anchor_resolves_to_body_line_id():
-    payload = convert_record(_sample_record())
-    body_line_id = payload["regions"]["body"][0]["line_id"]
-    marg = payload["regions"]["marginalia"][0]
-    assert marg["marker_id"] == "ⁱ"
-    assert marg["marker_link_target"] == body_line_id
-
-
-def test_text_gold_uses_raw_ocr_text_in_place():
+def test_legacy_phase3a_fields_are_dropped():
     payload = convert_record(_sample_record())
     body0 = payload["regions"]["body"][0]
-    assert body0["text_gold"] == "First body æ line"
-    assert body0["contains_ae_target"] is True
-    assert body0["review_status"] == "draft"
-    assert body0["reviewer"] == ""
-    # OCR provenance preserved alongside.
-    assert body0["ocr_confidence"] == 0.95
+    for field in (
+        "contains_ae_target",
+        "contains_marker",
+        "uncertain_ae",
+        "marker_uncertain",
+        "glyph_counts",
+        "marker_link_target",
+    ):
+        assert field not in body0, f"{field} should not be present"
+
+
+def test_text_ocr_original_baseline_is_set():
+    payload = convert_record(_sample_record())
+    for region_lines in payload["regions"].values():
+        for line in region_lines:
+            assert "text_ocr_original" in line
+            assert line["text_ocr_original"] == line["text_gold"]
+
+
+def test_body_lines_have_markers_array():
+    payload = convert_record(_sample_record())
+    for body_line in payload["regions"]["body"]:
+        assert isinstance(body_line.get("markers"), list)
+
+
+def test_marginalia_coalesce_into_two_footnotes():
+    """Same-anchor + adjacent-anchor continuation should produce 2 logical
+    footnotes from 4 raw marginalia fragments."""
+    payload = convert_record(_sample_record())
+    footnotes = payload["footnotes"]
+    assert len(footnotes) == 2
+    # Numbered sequentially per page.
+    assert [fn["marker_number"] for fn in footnotes] == [1, 2]
+    # Both footnotes get a kind defaulted to citation.
+    assert all(fn["kind"] == "citation" for fn in footnotes)
+    # Each carries provenance.
+    assert all(fn["source_region"] == "marginalia" for fn in footnotes)
+
+
+def test_first_footnote_coalesces_three_fragments():
+    payload = convert_record(_sample_record())
+    fn1 = payload["footnotes"][0]
+    # Anchored to body line 1 -> body_l0002 (1-based index in line_id).
+    assert fn1["body_line_id"] == payload["regions"]["body"][1]["line_id"]
+    assert "Niceph" in fn1["text_gold"]
+    assert "Eccleſiaſt" in fn1["text_gold"]
+    assert "lib.2" in fn1["text_gold"]
+    assert len(fn1["source_marginalia_line_ids"]) == 3
+
+
+def test_anchored_body_line_gets_marker_record():
+    payload = convert_record(_sample_record())
+    body1 = payload["regions"]["body"][1]
+    assert len(body1["markers"]) == 1
+    marker = body1["markers"][0]
+    assert marker["number"] == 1
+    assert marker["footnote_id"] == payload["footnotes"][0]["footnote_id"]
+    assert marker["char_offset"] is None
 
 
 def test_meta_carries_ocr_provenance():
@@ -110,6 +200,45 @@ def test_meta_carries_ocr_provenance():
     assert meta["ocr_lang"] == ["lat", "grc"]
     assert meta["annotation_status"] == "ocr_seeded"
     assert payload["source_pdf"] == "00_source_pdf/x.pdf"
+
+
+def test_pilot_footnote_region_mapped_into_marginalia():
+    record = _sample_record()
+    record["lines"].append(
+        {
+            "region": "footnote",
+            "line_index": 99,
+            "text_raw_ocr": "stray footnote text",
+            "confidence": 0.9,
+            "illegible": False,
+            "marker_id": "",
+            "marginalia_anchor_index": None,
+        }
+    )
+    payload = convert_record(record)
+    assert "footnote" not in payload["regions"]
+    # Stray footnote text rolled into marginalia for preservation.
+    marg_texts = [m["text_gold"] for m in payload["regions"]["marginalia"]]
+    assert "stray footnote text" in marg_texts
+
+
+def test_orphan_marginalia_appears_in_footnotes_without_body_anchor():
+    record = _sample_record()
+    record["lines"].append(
+        {
+            "region": "marginalia",
+            "line_index": 50,
+            "text_raw_ocr": "Orphan note.",
+            "confidence": 0.9,
+            "illegible": False,
+            "marker_id": "",
+            "marginalia_anchor_index": 999,  # No body line at this index.
+        }
+    )
+    payload = convert_record(record)
+    orphans = [fn for fn in payload["footnotes"] if fn["body_line_id"] == ""]
+    assert len(orphans) == 1
+    assert orphans[0]["text_gold"] == "Orphan note."
 
 
 def test_write_phase3b_files_refuses_overwrite_by_default(tmp_path):
@@ -126,4 +255,5 @@ def test_write_phase3b_files_overwrite_replaces(tmp_path):
     assert written == [target]
     payload = json.loads(target.read_text(encoding="utf-8"))
     assert payload["page_id"] == "p0001"
-    assert payload["regions"]["body"][0]["text_gold"] == "First body æ line"
+    assert payload["regions"]["body"][0]["text_gold"] == "First body line."
+    assert isinstance(payload["footnotes"], list)


### PR DESCRIPTION
## Summary

Full redesign of the Phase 3b annotation editor for Gemini-OCR output, replacing the legacy Tesseract-era line-card UI with a document-shaped editor and adding an append-only edit log to support prompt refinement.

## Schema (`pilot_to_phase3b.py`)

- Four regions: `header` / `body` / `marginalia` / `catchword` (legacy `footnote` region dropped)
- New top-level `footnotes[]` array auto-built by coalescing marginalia
  - Same-anchor fragments always merge; adjacent-anchor fragments merge only when the next starts lowercase or with a hyphen
  - Hyphenation across fragments is repaired during join
- Body lines carry structured `markers[] { number, footnote_id, char_offset }`
- Every line and footnote carries a frozen `text_ocr_original` baseline
- Legacy `contains_ae_target` / `contains_marker` / `glyph_counts` / `marker_link_target` etc. dropped

## Editor (`annotation_ui.html` / `.js` / `.css`)

- Page-meta card on top (`page_num`, `source_pdf`, `ocr_page_summary`, statuses, OCR provenance read-only)
- Header section
- Body + Marginalia 2-column grid: each body row paired with its anchored marginalia block (visually outlined per coalesced group)
- Sticky "unanchored marginalia" rail above the grid
- "+ Footnote here" button per body line; anchor dropdowns on marginalia and footnote cards
- Footnotes section with numbered cards, `kind` selector (`citation` / `gloss` / `cross_ref` / `not_a_note` / `other`), and re-anchor dropdown
- Markers render as superscript badges derived from `markers[]`; auto-renumber on every insert / delete / re-anchor
- Catchword strip at bottom

## Edit log (`annotation_ui.py`)

- `POST /api/page/<id>` diffs old vs new payload and appends per-field entries to a sidecar `page_pNNNN.edits.jsonl` (scopes: `line`, `body_marker`, `footnote`, `page_meta`, `page`)
- Append-only, retained for prompt refinement and editorial provenance
- Slim validator: enums + footnote_id integrity + region whitelist; tolerates legacy fields for back-compat

## Tests

69 passing (was 56). Added 7 converter cases covering coalescing / footnote build / region remap, plus 5 edit-log integration cases via Flask test client.