### PR TITLE
Editor: simplify OCR bar; add Remove button to marginalia

### DIFF
--- a/08_working_scratch/phase3b/ui/static/annotation_ui.js
+++ b/08_working_scratch/phase3b/ui/static/annotation_ui.js
@@ -495,6 +495,7 @@ function buildMarginaliaCard(line) {
       <span class="line-id">${safeId}</span>
       <div class="line-head-right">
         <input class="marker-id-mini" type="text" data-field="marker_id" placeholder="m" value="${safeMarker}">
+        <button type="button" class="line-remove-btn marginalia-remove-btn" title="Remove this marginalia line">Remove</button>
       </div>
     </div>
     <textarea class="text-gold" data-field="text_gold" rows="1">${safeText}</textarea>
@@ -527,7 +528,72 @@ function buildMarginaliaCard(line) {
     setMarginaliaAnchor(line, bodyLineId, offset);
     renderAll();
   });
+  const removeBtn = card.querySelector(".marginalia-remove-btn");
+  if (removeBtn) {
+    removeBtn.addEventListener("click", () => removeMarginaliaLine(line));
+  }
   return card;
+}
+
+function removeMarginaliaLine(line) {
+  if (!currentPayload) return;
+  const marg = currentPayload.regions?.marginalia;
+  if (!Array.isArray(marg)) return;
+  const idx = marg.findIndex((l) => l.line_id === line.line_id);
+  if (idx < 0) return;
+
+  // Snapshot the line and any footnote(s) referencing it so undo can restore both.
+  const lineSnapshot = clone(marg[idx]);
+  const fns = currentPayload.footnotes || [];
+  const fnSnapshots = fns
+    .map((fn, i) => ({ index: i, fn: clone(fn) }))
+    .filter(({ fn }) =>
+      Array.isArray(fn.source_marginalia_line_ids) &&
+      fn.source_marginalia_line_ids.includes(line.line_id)
+    );
+
+  // Remove the marginalia line.
+  marg.splice(idx, 1);
+
+  // Detach from any footnote and drop now-empty marginalia-derived footnotes.
+  fns.forEach((fn) => {
+    if (Array.isArray(fn.source_marginalia_line_ids)) {
+      fn.source_marginalia_line_ids = fn.source_marginalia_line_ids.filter(
+        (id) => id !== line.line_id
+      );
+    }
+  });
+  for (let i = fns.length - 1; i >= 0; i--) {
+    const fn = fns[i];
+    if (
+      fn.source_region === "marginalia" &&
+      (!fn.source_marginalia_line_ids || fn.source_marginalia_line_ids.length === 0) &&
+      !fn.text_gold
+    ) {
+      fns.splice(i, 1);
+    }
+  }
+  renumberFootnotes();
+
+  pushUndo(`Remove marginalia ${lineSnapshot.line_id || idx + 1}`, () => {
+    const margList = currentPayload.regions.marginalia || (currentPayload.regions.marginalia = []);
+    margList.splice(Math.min(idx, margList.length), 0, lineSnapshot);
+    const fnList = currentPayload.footnotes || (currentPayload.footnotes = []);
+    fnSnapshots
+      .slice()
+      .sort((a, b) => a.index - b.index)
+      .forEach(({ index, fn }) => {
+        const existing = fnList.findIndex((f) => f.footnote_id === fn.footnote_id);
+        if (existing >= 0) {
+          fnList[existing] = fn;
+        } else {
+          fnList.splice(Math.min(index, fnList.length), 0, fn);
+        }
+      });
+    renumberFootnotes();
+    renderAll();
+  });
+  renderAll();
 }
 
 function resolveMarginaliaAnchor(marginaliaLine) {
@@ -1033,7 +1099,6 @@ if (window.__PAGES__ && window.__PAGES__.length > 0) {
 // ---------------------------------------------------------------------------
 const ocrPdfSelect = document.getElementById("ocrPdfSelect");
 const ocrPageInput = document.getElementById("ocrPageInput");
-const ocrPartSelect = document.getElementById("ocrPartSelect");
 const ocrOverwrite = document.getElementById("ocrOverwrite");
 const ocrRunBtn = document.getElementById("ocrRunBtn");
 const ocrStatus = document.getElementById("ocrStatus");
@@ -1086,7 +1151,8 @@ async function pollOcrJob(jobId, pageId) {
 async function runOcr(forceOverwrite) {
   const pdf = ocrPdfSelect?.value;
   const page = parseInt(ocrPageInput?.value || "0", 10);
-  const part = ocrPartSelect?.value || "part1";
+  // Derive part from the PDF filename (e.g. "..._Part2.pdf" -> part2; default part1).
+  const part = /_part2/i.test(String(pdf || "")) ? "part2" : "part1";
   if (!pdf) { setOcrStatus("Pick a PDF first.", true); return; }
   if (!Number.isFinite(page) || page < 1) { setOcrStatus("Page must be a positive integer.", true); return; }
 

--- a/08_working_scratch/phase3b/ui/templates/annotation_ui.html
+++ b/08_working_scratch/phase3b/ui/templates/annotation_ui.html
@@ -29,11 +29,6 @@
     <select id="ocrPdfSelect"></select>
     <label for="ocrPageInput">Page</label>
     <input id="ocrPageInput" type="number" min="1" value="1" style="width: 5em">
-    <label for="ocrPartSelect">Part</label>
-    <select id="ocrPartSelect">
-      <option value="part1">part1</option>
-      <option value="part2">part2</option>
-    </select>
     <label><input id="ocrOverwrite" type="checkbox"> Overwrite</label>
     <button id="ocrRunBtn" type="button">Run Gemini OCR</button>
     <span id="ocrStatus" class="status"></span>

--- a/08_working_scratch/phase3b/ui/templates/pdf_viewer.html
+++ b/08_working_scratch/phase3b/ui/templates/pdf_viewer.html
@@ -53,6 +53,12 @@
       background: #d7cbb8;
       margin: 0 0.25rem;
     }
+    .zoom-label {
+      min-width: 3.2rem;
+      text-align: right;
+      color: #6b5a40;
+      font-variant-numeric: tabular-nums;
+    }
     .stage {
       overflow: auto;
       display: flex;
@@ -90,6 +96,7 @@
         <option value="4">400%</option>
       </select>
       <button id="zoomInBtn" type="button" title="Zoom in (+)">+</button>
+      <span id="zoomLabel" class="zoom-label"></span>
     </div>
     <div class="stage">
       <canvas id="pdfCanvas"></canvas>
@@ -112,7 +119,10 @@
     const zoomInBtn = document.getElementById("zoomInBtn");
     const zoomOutBtn = document.getElementById("zoomOutBtn");
     const zoomSelect = document.getElementById("zoomSelect");
+    const zoomLabel = document.getElementById("zoomLabel");
     const stageEl = document.querySelector(".stage");
+    let activeRenderTask = null;
+    let lastRenderedScale = null;
 
     const ZOOM_STEPS = [0.5, 0.75, 1, 1.25, 1.5, 2, 3, 4];
     const ZOOM_KEY = "ussherInPdfZoom";
@@ -150,10 +160,19 @@
     }
 
     function syncZoomSelect() {
-      if (!zoomSelect) return;
-      const asString = String(currentZoom);
-      const has = Array.from(zoomSelect.options).some((o) => o.value === asString);
-      zoomSelect.value = has ? asString : "";
+      if (zoomSelect) {
+        const asString = String(currentZoom);
+        const has = Array.from(zoomSelect.options).some((o) => o.value === asString);
+        zoomSelect.value = has ? asString : "";
+      }
+      if (zoomLabel) {
+        if (currentZoom === "page-fit" || currentZoom === "page-width") {
+          const pct = lastRenderedScale ? Math.round(lastRenderedScale * 100) + "%" : "…";
+          zoomLabel.textContent = pct;
+        } else {
+          zoomLabel.textContent = Math.round(Number(currentZoom) * 100) + "%";
+        }
+      }
     }
 
     function stepZoom(direction) {
@@ -188,22 +207,43 @@
       currentPage = clampPage(pageNum);
       updateControls();
 
+      // Cancel any in-flight render so a new zoom or page change takes effect immediately.
+      if (activeRenderTask) {
+        try { activeRenderTask.cancel(); } catch (e) { /* ignore */ }
+        activeRenderTask = null;
+      }
+
       const token = ++renderToken;
       const page = await pdfDoc.getPage(currentPage);
+      if (token !== renderToken) return;
       const viewport1 = page.getViewport({ scale: 1 });
       const scale = effectiveScale(viewport1);
+      lastRenderedScale = scale;
       const viewport = page.getViewport({ scale });
       canvas.width = Math.ceil(viewport.width);
       canvas.height = Math.ceil(viewport.height);
+      canvas.style.width = Math.ceil(viewport.width) + "px";
+      canvas.style.height = Math.ceil(viewport.height) + "px";
 
-      await page.render({
-        canvasContext: ctx,
-        viewport,
-      }).promise;
+      const task = page.render({ canvasContext: ctx, viewport });
+      activeRenderTask = task;
+      try {
+        await task.promise;
+      } catch (err) {
+        // Render cancelled by a newer call; safe to ignore.
+        if (!err || err.name !== "RenderingCancelledException") {
+          console.error(err);
+        }
+        return;
+      } finally {
+        if (activeRenderTask === task) activeRenderTask = null;
+      }
 
       if (token !== renderToken) {
         return;
       }
+
+      syncZoomSelect();
 
       // Keep iframe URL hash in sync so refresh/open-in-new-tab preserves the page.
       if (location.hash !== `#page=${currentPage}`) {


### PR DESCRIPTION
Two small UX improvements:

**1. OCR bar — drop the Part select.** Now that the PDF dropdown lists the actual source files, the separate `part1` / `part2` selector is redundant. The client now derives `part` from the chosen filename (matches `_Part2` case-insensitively, otherwise `part1`). The `/api/ocr/start` payload contract is unchanged.

**2. Marginalia — Remove button on every card.** Each marginalia card now has a `Remove` button in its header, matching the existing header / body / catchword pattern. This removes the line in place (no need to scroll to a separate footnote panel) and:
- Detaches the line from any footnote's `source_marginalia_line_ids`
- Drops empty marginalia-derived footnotes
- Pushes a full undo entry that restores both the line and any modified/removed footnotes
- Renumbers remaining footnotes
- Works equally for anchored cards (next to a body line) and unanchored cards (top rail)

All 69 tests pass. UI-only change.