### PR TITLE
Editor: add edition config (1687 vs 1847 Elrington & Todd)

### DIFF
--- a/08_working_scratch/phase3b/scripts/annotation_ui.py
+++ b/08_working_scratch/phase3b/scripts/annotation_ui.py
@@ -22,6 +22,7 @@ PIPELINE_SCRIPTS_DIR = ROOT / "08_working_scratch" / "pipeline_scripts"
 
 ALLOWED_REVIEW_STATUS = {"draft", "reviewed", "locked"}
 ALLOWED_FOOTNOTE_KIND = {"citation", "gloss", "cross_ref", "not_a_note", "other"}
+ALLOWED_EDITIONS = {"1687_second", "1847_elrington_todd"}
 SCHEMA_REGIONS = ("header", "body", "marginalia", "catchword")
 
 app = Flask(__name__, template_folder=str(TEMPLATE_DIR), static_folder=str(STATIC_DIR))
@@ -147,6 +148,12 @@ def _validate_payload(payload: dict) -> list[str]:
     if meta_review_status and meta_review_status not in ALLOWED_REVIEW_STATUS:
         errors.append(f"meta.review_status: invalid value '{meta_review_status}'")
 
+    # Edition is optional for legacy payloads, but must be from the allowed
+    # set when present. Treat empty/missing as legacy 1687.
+    edition = payload.get("edition", "")
+    if edition and str(edition) not in ALLOWED_EDITIONS:
+        errors.append(f"edition: invalid value '{edition}'")
+
     return errors
 
 
@@ -170,7 +177,7 @@ _PAGE_META_DIFF_FIELDS = (
     "notes",
     "ocr_page_summary",
 )
-_PAGE_TOPLEVEL_DIFF_FIELDS = ("page_num", "source_pdf")
+_PAGE_TOPLEVEL_DIFF_FIELDS = ("page_num", "source_pdf", "edition")
 
 
 def _index_by(items, key: str) -> dict:
@@ -450,7 +457,13 @@ def _job_get(job_id: str) -> dict | None:
 
 
 def _run_ocr_job(
-    job_id: str, pdf_path: Path, page_num: int, part: str, page_id: str, overwrite: bool
+    job_id: str,
+    pdf_path: Path,
+    page_num: int,
+    part: str,
+    page_id: str,
+    overwrite: bool,
+    edition: str,
 ) -> None:
     pilot_dir = PILOT_OCR_DIR / part
     pilot_json = pilot_dir / f"{part}_pilot_ocr.json"
@@ -517,7 +530,7 @@ def _run_ocr_job(
         except ValueError:
             rel_pdf = str(pdf_path)
 
-        payload = convert_record(record, source_pdf=rel_pdf)
+        payload = convert_record(record, source_pdf=rel_pdf, edition=edition)
 
         if target_annotation.exists() and not overwrite:
             _job_set(
@@ -554,6 +567,7 @@ def api_ocr_start():
     except (TypeError, ValueError):
         return jsonify({"ok": False, "error": "page must be an integer"}), 400
     part = str(body.get("part", "part1")).strip() or "part1"
+    edition = str(body.get("edition", "")).strip() or "1687_second"
     overwrite = bool(body.get("overwrite", False))
 
     if not pdf_name:
@@ -562,6 +576,16 @@ def api_ocr_start():
         return jsonify({"ok": False, "error": "page must be >= 1"}), 400
     if part not in {"part1", "part2"}:
         return jsonify({"ok": False, "error": "part must be 'part1' or 'part2'"}), 400
+    if edition not in ALLOWED_EDITIONS:
+        return (
+            jsonify(
+                {
+                    "ok": False,
+                    "error": f"edition must be one of {sorted(ALLOWED_EDITIONS)}",
+                }
+            ),
+            400,
+        )
 
     pdf_path = SOURCE_PDF_DIR / pdf_name
     if not pdf_path.exists() or pdf_path.suffix.lower() != ".pdf":
@@ -593,7 +617,7 @@ def api_ocr_start():
     )
     thread = threading.Thread(
         target=_run_ocr_job,
-        args=(job_id, pdf_path, page_num, part, page_id, overwrite),
+        args=(job_id, pdf_path, page_num, part, page_id, overwrite, edition),
         daemon=True,
     )
     thread.start()

--- a/08_working_scratch/phase3b/ui/static/annotation_ui.css
+++ b/08_working_scratch/phase3b/ui/static/annotation_ui.css
@@ -454,3 +454,121 @@ input[type="text"], select, textarea {
 
 
 /* === Phase C redesign === */
+
+/* ---------------------------------------------------------------------------
+ * Edition support: badge in meta card, blurb in OCR bar, chooser modal,
+ * sticky footnote pane for the 1847 layout.
+ * --------------------------------------------------------------------------- */
+.edition-blurb {
+  flex: 1 1 100%;
+  margin-top: 0.25rem;
+  font-size: 0.78rem;
+  color: #6b6052;
+  font-style: italic;
+}
+.edition-badge-row {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+.edition-badge {
+  display: inline-block;
+  padding: 0.1rem 0.5rem;
+  background: #f1e7d0;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  font-size: 0.78rem;
+}
+.edition-badge[data-edition="1847_elrington_todd"] {
+  background: #e1ecf2;
+  border-color: #b3c9d3;
+}
+
+/* Sticky footnote pane (1847 layout) — pinned at the bottom of the editor pane. */
+.sticky-footnote-pane {
+  position: sticky;
+  bottom: 0;
+  background: var(--panel);
+  border-top: 2px solid var(--accent);
+  box-shadow: 0 -4px 8px rgba(0, 0, 0, 0.05);
+  z-index: 5;
+  max-height: 40vh;
+  overflow-y: auto;
+}
+
+/* In 1847 mode, body rows take full width (no marginalia column). */
+body.layout-1847 .body-grid {
+  grid-template-columns: 1fr !important;
+}
+body.layout-1847 .body-row {
+  grid-template-columns: 1fr !important;
+}
+body.layout-1847 .marg-cell {
+  display: none;
+}
+
+/* Edition chooser modal. */
+.modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(20, 14, 4, 0.45);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+.modal-overlay[hidden] { display: none; }
+.modal-card {
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  padding: 1.25rem 1.5rem;
+  max-width: 32rem;
+  width: 92%;
+  box-shadow: 0 12px 36px rgba(0, 0, 0, 0.25);
+}
+.modal-card h2 {
+  margin: 0 0 0.5rem;
+  font-size: 1.1rem;
+}
+.modal-intro {
+  margin: 0 0 0.85rem;
+  font-size: 0.88rem;
+  color: #4d4434;
+}
+.edition-choices {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+.edition-choice {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  grid-template-rows: auto auto;
+  gap: 0.15rem 0.6rem;
+  padding: 0.55rem 0.7rem;
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  cursor: pointer;
+  background: #fbf7ec;
+}
+.edition-choice:hover { background: #f4ecd5; }
+.edition-choice input { grid-row: 1 / span 2; align-self: center; }
+.edition-choice-title { font-weight: 600; font-size: 0.95rem; }
+.edition-choice-desc { font-size: 0.82rem; color: #6b6052; }
+.modal-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+  margin-top: 1rem;
+}
+.primary-btn {
+  border: 1px solid var(--accent);
+  background: var(--accent);
+  color: #fff;
+  border-radius: 4px;
+  padding: 0.3rem 0.8rem;
+  font: inherit;
+  cursor: pointer;
+}
+.primary-btn:hover { filter: brightness(1.05); }

--- a/08_working_scratch/phase3b/ui/static/annotation_ui.js
+++ b/08_working_scratch/phase3b/ui/static/annotation_ui.js
@@ -41,6 +41,43 @@ const unanchoredMarginaliaContainer = document.getElementById(
 );
 const footnoteContainer = document.getElementById("footnoteContainer");
 const catchwordContainer = document.getElementById("catchwordContainer");
+const footnoteSection = document.getElementById("footnoteSection");
+const stickyFootnoteSection = document.getElementById("stickyFootnoteSection");
+const stickyFootnoteContainer = document.getElementById("stickyFootnoteContainer");
+const bodySection = document.getElementById("bodySection");
+const metaEditionBadge = document.getElementById("metaEditionBadge");
+const metaEditionChangeBtn = document.getElementById("metaEditionChangeBtn");
+
+// Edition chooser modal.
+const editionChooserModal = document.getElementById("editionChooserModal");
+const editionChooserConfirmBtn = document.getElementById("editionChooserConfirmBtn");
+const editionChooserCancelBtn = document.getElementById("editionChooserCancelBtn");
+
+const EDITIONS = {
+  "1687_second": {
+    label: "1687 Second Edition",
+    blurb: "Second-edition typesetting with marginalia rail; long-s, ligatures, Greek/Latin paleography.",
+    hasMarginalia: true,
+    stickyFootnotes: false,
+  },
+  "1847_elrington_todd": {
+    label: "Elrington & Todd 1847",
+    blurb: "Reprint with no marginalia; footnotes typeset at the bottom of the page; 19th-c. Latin/Greek lithography and ligatures.",
+    hasMarginalia: false,
+    stickyFootnotes: true,
+  },
+};
+const DEFAULT_EDITION = "1687_second";
+const EDITION_LS_KEY = "ussherInEdition";
+
+function editionConfig(key) {
+  return EDITIONS[key] || EDITIONS[DEFAULT_EDITION];
+}
+
+function currentEdition() {
+  const v = String(currentPayload?.edition || "");
+  return EDITIONS[v] ? v : DEFAULT_EDITION;
+}
 
 const addHeaderBtn = document.getElementById("addHeaderBtn");
 const addBodyBtn = document.getElementById("addBodyBtn");
@@ -213,6 +250,9 @@ function normalizePayload(payload) {
 
   payload.meta = payload.meta || {};
   payload.meta.reviewer = DEFAULT_REVIEWER;
+  // Normalise edition: empty/legacy stays empty so loadPage can prompt.
+  if (typeof payload.edition !== "string") payload.edition = "";
+  if (payload.edition && !EDITIONS[payload.edition]) payload.edition = "";
 }
 
 function applyDefaultReviewer(payload) {
@@ -833,22 +873,26 @@ function renderBodyWithMarginalia() {
 
   const bodyLines = currentPayload?.regions?.body || [];
   const marginaliaLines = currentPayload?.regions?.marginalia || [];
+  const cfg = editionConfig(currentEdition());
+  const showMarginalia = cfg.hasMarginalia;
 
   // Group marginalia by anchored body_line_id (resolved via footnotes).
   const bodyToMarginalia = new Map();
   const unanchored = [];
-  marginaliaLines.forEach((line) => {
-    const anchor = resolveMarginaliaAnchor(line);
-    if (anchor) {
-      if (!bodyToMarginalia.has(anchor)) bodyToMarginalia.set(anchor, []);
-      bodyToMarginalia.get(anchor).push(line);
-    } else {
-      unanchored.push(line);
-    }
-  });
+  if (showMarginalia) {
+    marginaliaLines.forEach((line) => {
+      const anchor = resolveMarginaliaAnchor(line);
+      if (anchor) {
+        if (!bodyToMarginalia.has(anchor)) bodyToMarginalia.set(anchor, []);
+        bodyToMarginalia.get(anchor).push(line);
+      } else {
+        unanchored.push(line);
+      }
+    });
+  }
 
   // Unanchored rail at the top.
-  if (unanchored.length > 0) {
+  if (showMarginalia && unanchored.length > 0) {
     const heading = document.createElement("div");
     heading.className = "unanchored-heading";
     heading.textContent = `Unanchored marginalia (${unanchored.length})`;
@@ -882,9 +926,11 @@ function renderBodyWithMarginalia() {
 
     const margCell = document.createElement("div");
     margCell.className = "marg-cell";
-    const margForLine = bodyToMarginalia.get(line.line_id) || [];
-    if (margForLine.length > 0) {
-      margCell.appendChild(buildMarginaliaBlock(margForLine));
+    if (showMarginalia) {
+      const margForLine = bodyToMarginalia.get(line.line_id) || [];
+      if (margForLine.length > 0) {
+        margCell.appendChild(buildMarginaliaBlock(margForLine));
+      }
     }
 
     row.appendChild(bodyCell);
@@ -894,16 +940,21 @@ function renderBodyWithMarginalia() {
 }
 
 function renderFootnotes() {
-  footnoteContainer.innerHTML = "";
+  const cfg = editionConfig(currentEdition());
+  const target = cfg.stickyFootnotes ? stickyFootnoteContainer : footnoteContainer;
+  // Clear both so stale cards from the other edition layout don't linger.
+  if (footnoteContainer) footnoteContainer.innerHTML = "";
+  if (stickyFootnoteContainer) stickyFootnoteContainer.innerHTML = "";
+  if (!target) return;
   const fns = currentPayload?.footnotes || [];
   if (fns.length === 0) {
     const empty = document.createElement("div");
     empty.className = "footnote-empty";
     empty.textContent = "No footnotes yet. Use \u201c+ Footnote here\u201d on a body line, or anchor a marginalia.";
-    footnoteContainer.appendChild(empty);
+    target.appendChild(empty);
     return;
   }
-  fns.forEach((fn) => footnoteContainer.appendChild(buildFootnoteCard(fn)));
+  fns.forEach((fn) => target.appendChild(buildFootnoteCard(fn)));
 }
 
 function renderCatchword() {
@@ -929,10 +980,31 @@ function renderCatchword() {
 
 function renderAll() {
   if (!currentPayload) return;
+  applyEditionLayout();
   renderHeader();
   renderBodyWithMarginalia();
   renderFootnotes();
   renderCatchword();
+}
+
+function applyEditionLayout() {
+  const cfg = editionConfig(currentEdition());
+  // Toggle a class on <body> so CSS can target the layout variant.
+  document.body.classList.toggle("layout-1847", !cfg.hasMarginalia);
+  document.body.classList.toggle("layout-1687", cfg.hasMarginalia);
+  // Show/hide marginalia rail container; the renderer also checks the flag,
+  // but hiding the empty container avoids leaving a gap above the body grid.
+  if (unanchoredMarginaliaContainer) {
+    unanchoredMarginaliaContainer.hidden = !cfg.hasMarginalia;
+  }
+  // Inline footnote section vs. sticky pane at bottom.
+  if (footnoteSection) footnoteSection.hidden = cfg.stickyFootnotes;
+  if (stickyFootnoteSection) stickyFootnoteSection.hidden = !cfg.stickyFootnotes;
+  // Edition badge in meta-card.
+  if (metaEditionBadge) {
+    metaEditionBadge.textContent = cfg.label;
+    metaEditionBadge.dataset.edition = currentEdition();
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -975,6 +1047,10 @@ async function loadPage(pageId) {
     normalizePayload(currentPayload);
     applyDefaultReviewer(currentPayload);
     renumberFootnotes();
+    if (!currentPayload.edition) {
+      const picked = await chooseEditionInteractive({ title: "Select edition for this page" });
+      currentPayload.edition = picked || DEFAULT_EDITION;
+    }
     bindMeta(currentPayload);
     renderAll();
     clearUndoStack();
@@ -1099,9 +1175,90 @@ if (window.__PAGES__ && window.__PAGES__.length > 0) {
 // ---------------------------------------------------------------------------
 const ocrPdfSelect = document.getElementById("ocrPdfSelect");
 const ocrPageInput = document.getElementById("ocrPageInput");
+const ocrEditionSelect = document.getElementById("ocrEditionSelect");
+const ocrEditionBlurb = document.getElementById("ocrEditionBlurb");
 const ocrOverwrite = document.getElementById("ocrOverwrite");
 const ocrRunBtn = document.getElementById("ocrRunBtn");
 const ocrStatus = document.getElementById("ocrStatus");
+
+// Restore last-picked edition from localStorage and wire the blurb.
+if (ocrEditionSelect) {
+  const saved = (typeof localStorage !== "undefined" && localStorage.getItem(EDITION_LS_KEY)) || "";
+  if (EDITIONS[saved]) ocrEditionSelect.value = saved;
+  const updateBlurb = () => {
+    if (ocrEditionBlurb) {
+      ocrEditionBlurb.textContent = editionConfig(ocrEditionSelect.value).blurb;
+    }
+  };
+  updateBlurb();
+  ocrEditionSelect.addEventListener("change", () => {
+    try { localStorage.setItem(EDITION_LS_KEY, ocrEditionSelect.value); } catch (e) { /* ignore */ }
+    updateBlurb();
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Edition chooser modal (shown when loading a page with no edition recorded
+// or when the user clicks "Change..." in the meta card).
+// ---------------------------------------------------------------------------
+let _editionChooserResolver = null;
+
+function chooseEditionInteractive({ title, currentValue } = {}) {
+  if (!editionChooserModal) return Promise.resolve(DEFAULT_EDITION);
+  const titleEl = document.getElementById("editionChooserTitle");
+  if (titleEl && title) titleEl.textContent = title;
+  const initial = EDITIONS[currentValue] ? currentValue : DEFAULT_EDITION;
+  editionChooserModal.querySelectorAll('input[name="editionChoice"]').forEach((r) => {
+    r.checked = r.value === initial;
+  });
+  editionChooserModal.hidden = false;
+  return new Promise((resolve) => {
+    _editionChooserResolver = resolve;
+  });
+}
+
+function closeEditionChooser(value) {
+  if (!editionChooserModal) return;
+  editionChooserModal.hidden = true;
+  const resolve = _editionChooserResolver;
+  _editionChooserResolver = null;
+  if (resolve) resolve(value);
+}
+
+if (editionChooserConfirmBtn) {
+  editionChooserConfirmBtn.addEventListener("click", () => {
+    const picked = editionChooserModal.querySelector('input[name="editionChoice"]:checked');
+    closeEditionChooser(picked ? picked.value : DEFAULT_EDITION);
+  });
+}
+if (editionChooserCancelBtn) {
+  editionChooserCancelBtn.addEventListener("click", () => closeEditionChooser(null));
+}
+if (editionChooserModal) {
+  editionChooserModal.addEventListener("click", (event) => {
+    if (event.target === editionChooserModal) closeEditionChooser(null);
+  });
+}
+
+if (metaEditionChangeBtn) {
+  metaEditionChangeBtn.addEventListener("click", async () => {
+    if (!currentPayload) return;
+    const picked = await chooseEditionInteractive({
+      title: "Change edition for this page",
+      currentValue: currentEdition(),
+    });
+    if (!picked || picked === currentEdition()) return;
+    currentPayload.edition = picked;
+    renderAll();
+    setStatus(`Edition changed to ${editionConfig(picked).label} (unsaved)`);
+  });
+}
+
+// "+ Footnote" in the sticky pane uses the same flow as the inline button.
+const addStickyFootnoteBtn = document.getElementById("addStickyFootnoteBtn");
+if (addStickyFootnoteBtn) {
+  addStickyFootnoteBtn.addEventListener("click", () => addFootnoteAnchored(""));
+}
 
 function setOcrStatus(msg, isError = false) {
   if (!ocrStatus) return;
@@ -1153,6 +1310,9 @@ async function runOcr(forceOverwrite) {
   const page = parseInt(ocrPageInput?.value || "0", 10);
   // Derive part from the PDF filename (e.g. "..._Part2.pdf" -> part2; default part1).
   const part = /_part2/i.test(String(pdf || "")) ? "part2" : "part1";
+  const edition = ocrEditionSelect?.value && EDITIONS[ocrEditionSelect.value]
+    ? ocrEditionSelect.value
+    : DEFAULT_EDITION;
   if (!pdf) { setOcrStatus("Pick a PDF first.", true); return; }
   if (!Number.isFinite(page) || page < 1) { setOcrStatus("Page must be a positive integer.", true); return; }
 
@@ -1162,7 +1322,7 @@ async function runOcr(forceOverwrite) {
     const res = await fetch("/api/ocr/start", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ pdf, page, part, overwrite: !!(forceOverwrite || ocrOverwrite?.checked) }),
+      body: JSON.stringify({ pdf, page, part, edition, overwrite: !!(forceOverwrite || ocrOverwrite?.checked) }),
     });
     const data = await res.json().catch(() => ({}));
     if (res.status === 409 && data.error === "annotation_exists") {

--- a/08_working_scratch/phase3b/ui/templates/annotation_ui.html
+++ b/08_working_scratch/phase3b/ui/templates/annotation_ui.html
@@ -29,9 +29,15 @@
     <select id="ocrPdfSelect"></select>
     <label for="ocrPageInput">Page</label>
     <input id="ocrPageInput" type="number" min="1" value="1" style="width: 5em">
+    <label for="ocrEditionSelect">Edition</label>
+    <select id="ocrEditionSelect">
+      <option value="1687_second">1687 Second Edition</option>
+      <option value="1847_elrington_todd">Elrington &amp; Todd 1847</option>
+    </select>
     <label><input id="ocrOverwrite" type="checkbox"> Overwrite</label>
     <button id="ocrRunBtn" type="button">Run Gemini OCR</button>
     <span id="ocrStatus" class="status"></span>
+    <span id="ocrEditionBlurb" class="edition-blurb"></span>
   </section>
 
   <section class="glyph-bar" id="glyphBar">
@@ -63,6 +69,12 @@
           </label>
           <label>Reviewer
             <input id="metaReviewer" type="text" readonly>
+          </label>
+          <label>Edition
+            <span class="edition-badge-row">
+              <span id="metaEditionBadge" class="edition-badge">&mdash;</span>
+              <button id="metaEditionChangeBtn" type="button" class="small-btn" title="Change edition for this page">Change…</button>
+            </span>
           </label>
         </div>
         <label>OCR page summary
@@ -106,6 +118,14 @@
         <div id="footnoteContainer"></div>
       </section>
 
+      <section class="region-section sticky-footnote-pane" id="stickyFootnoteSection" hidden>
+        <div class="section-head">
+          <h2>Footnotes (1847)</h2>
+          <button id="addStickyFootnoteBtn" type="button" class="small-btn">+ Footnote</button>
+        </div>
+        <div id="stickyFootnoteContainer"></div>
+      </section>
+
       <section class="region-section" id="catchwordSection">
         <div class="section-head">
           <h2>Catchword</h2>
@@ -128,6 +148,29 @@
       <iframe id="pdfFrame" title="Source PDF"></iframe>
     </section>
   </main>
+
+  <div id="editionChooserModal" class="modal-overlay" hidden>
+    <div class="modal-card" role="dialog" aria-labelledby="editionChooserTitle" aria-modal="true">
+      <h2 id="editionChooserTitle">Select edition</h2>
+      <p class="modal-intro">This page does not have an edition recorded yet. Pick which edition this page belongs to so the editor can show the right layout.</p>
+      <div class="edition-choices">
+        <label class="edition-choice">
+          <input type="radio" name="editionChoice" value="1687_second" checked>
+          <span class="edition-choice-title">1687 Second Edition</span>
+          <span class="edition-choice-desc">Second-edition typesetting with marginalia rail; long-s, ligatures, Greek/Latin paleography.</span>
+        </label>
+        <label class="edition-choice">
+          <input type="radio" name="editionChoice" value="1847_elrington_todd">
+          <span class="edition-choice-title">Elrington &amp; Todd 1847</span>
+          <span class="edition-choice-desc">Reprint with no marginalia; footnotes typeset at the bottom of the page; 19th-c. Latin/Greek lithography and ligatures.</span>
+        </label>
+      </div>
+      <div class="modal-actions">
+        <button id="editionChooserCancelBtn" type="button" class="small-btn">Cancel</button>
+        <button id="editionChooserConfirmBtn" type="button" class="primary-btn">Apply</button>
+      </div>
+    </div>
+  </div>
 
   <script>
     window.__PAGES__ = {{ pages|tojson }};

--- a/08_working_scratch/pipeline_scripts/pilot_to_phase3b.py
+++ b/08_working_scratch/pipeline_scripts/pilot_to_phase3b.py
@@ -44,6 +44,14 @@ from typing import Iterable
 PHASE3B_REGIONS = ("header", "body", "marginalia", "catchword")
 FOOTNOTE_KIND_DEFAULT = "citation"
 
+ALLOWED_EDITIONS = ("1687_second", "1847_elrington_todd")
+DEFAULT_EDITION = "1687_second"
+# Editions whose layout has no marginalia rail (footnotes typeset at bottom
+# of page). The converter still preserves any marginalia text the OCR
+# returned so a later edition switch is non-destructive, but the editor
+# hides the rail for these editions.
+EDITIONS_WITHOUT_MARGINALIA = frozenset({"1847_elrington_todd"})
+
 
 def _line_id(page_id: str, region: str, ordinal: int) -> str:
     return f"{page_id}_{region}_l{ordinal:04d}"
@@ -229,8 +237,16 @@ def _build_footnotes(
     return footnotes
 
 
-def convert_record(record: dict, *, source_pdf: str | None = None) -> dict:
+def convert_record(
+    record: dict,
+    *,
+    source_pdf: str | None = None,
+    edition: str | None = None,
+) -> dict:
     """Convert a single pilot-OCR page record into a Phase 3b payload."""
+    edition_value = edition or str(record.get("edition") or "") or DEFAULT_EDITION
+    if edition_value not in ALLOWED_EDITIONS:
+        edition_value = DEFAULT_EDITION
     page_id = str(record.get("page_id") or f"p{int(record.get('page_num', 0)):04d}")
     part = str(record.get("part", ""))
     page_num = int(record.get("page_num", 0))
@@ -281,6 +297,7 @@ def convert_record(record: dict, *, source_pdf: str | None = None) -> dict:
     payload: dict = {
         "page_id": page_id,
         "part": part,
+        "edition": edition_value,
         "source_pdf": source_pdf or "",
         "page_num": page_num,
         "regions": regions,
@@ -306,6 +323,7 @@ def write_phase3b_files(
     out_dir: Path,
     *,
     source_pdf: str | None = None,
+    edition: str | None = None,
     overwrite: bool = False,
 ) -> list[Path]:
     """Write one ``page_pNNNN.json`` per pilot record. Returns paths written.
@@ -315,7 +333,7 @@ def write_phase3b_files(
     out_dir.mkdir(parents=True, exist_ok=True)
     written: list[Path] = []
     for record in pilot_records:
-        payload = convert_record(record, source_pdf=source_pdf)
+        payload = convert_record(record, source_pdf=source_pdf, edition=edition)
         target = out_dir / f"page_{payload['page_id']}.json"
         if target.exists() and not overwrite:
             raise FileExistsError(str(target))
@@ -336,6 +354,12 @@ def main() -> int:
         help="Phase 3b annotations directory",
     )
     parser.add_argument("--source-pdf", default="", help="Source PDF path to embed")
+    parser.add_argument(
+        "--edition",
+        default=DEFAULT_EDITION,
+        choices=list(ALLOWED_EDITIONS),
+        help="Edition key written into the payload (default: %(default)s)",
+    )
     parser.add_argument("--overwrite", action="store_true")
     args = parser.parse_args()
 
@@ -346,6 +370,7 @@ def main() -> int:
         records,
         Path(args.out_dir),
         source_pdf=args.source_pdf or None,
+        edition=args.edition,
         overwrite=args.overwrite,
     )
     for path in written:

--- a/08_working_scratch/tests/test_pilot_to_phase3b.py
+++ b/08_working_scratch/tests/test_pilot_to_phase3b.py
@@ -257,3 +257,25 @@ def test_write_phase3b_files_overwrite_replaces(tmp_path):
     assert payload["page_id"] == "p0001"
     assert payload["regions"]["body"][0]["text_gold"] == "First body line."
     assert isinstance(payload["footnotes"], list)
+
+
+def test_default_edition_is_1687_when_not_specified():
+    payload = convert_record(_sample_record())
+    assert payload["edition"] == "1687_second"
+
+
+def test_edition_kwarg_overrides_default():
+    payload = convert_record(_sample_record(), edition="1847_elrington_todd")
+    assert payload["edition"] == "1847_elrington_todd"
+
+
+def test_unknown_edition_falls_back_to_default():
+    payload = convert_record(_sample_record(), edition="bogus_edition")
+    assert payload["edition"] == "1687_second"
+
+
+def test_edition_can_be_carried_on_record():
+    record = _sample_record()
+    record["edition"] = "1847_elrington_todd"
+    payload = convert_record(record)
+    assert payload["edition"] == "1847_elrington_todd"


### PR DESCRIPTION
Adds a first-class **edition** value to each annotation so the editor can render two distinct layouts.

## Editions

| Key | Label | Marginalia | Footnotes |
|---|---|---|---|
| `1687_second` | 1687 Second Edition | Side rail (current) | Inline section |
| `1847_elrington_todd` | Elrington & Todd 1847 | None | Sticky pane pinned at the bottom of the editor pane |

Per-character footnote anchoring (`markers[].char_offset`) already worked on both layouts — no schema change needed for that.

## Backend

- `pilot_to_phase3b.convert_record(...)` accepts an `edition` kwarg (or reads `record["edition"]`); writes `payload.edition`. Unknown values fall back to `1687_second`.
- `/api/ocr/start` accepts `edition`; whitelist `{1687_second, 1847_elrington_todd}`; passed through to `_run_ocr_job` and into `convert_record`.
- `_validate_payload` accepts the new field; rejects unknown values; missing/empty is allowed for legacy payloads.
- `_PAGE_TOPLEVEL_DIFF_FIELDS` now records edition changes in the edit-log sidecar.

## UI

- **OCR bar**: new "Edition" select with a small italic blurb that updates on change. Last-picked value is persisted to `localStorage` (`ussherInEdition`).
- **Meta card**: edition badge + "Change…" button that opens the chooser modal.
- **Edition chooser modal**: opens automatically when `loadPage` finds no `edition` recorded on the payload, so legacy pages get classified before render. Two radio options with a one-sentence description each.
- **Layout switching**:
  - 1687: unchanged.
  - 1847: `body.layout-1847` → marginalia rail and column hidden; "Footnotes (1847)" pane is `position: sticky; bottom: 0` inside the editor pane (max-height 40vh, scrolls), so footnotes are always visible while editing.
- "+ Footnote" button mirrored on the sticky pane; reuses `addFootnoteAnchored("")`.

## Out of scope (explicitly deferred)

- Edition-specific OCR prompt variants. The same prompt is used for both editions in this PR; will iterate after seeing real 1847 OCR output.
- Manifest schema changes — `build_manifest.py` will pick up `edition` automatically once we choose to add it; not required for current UI experimentation.

## Tests

73 passed (was 69), including 4 new tests covering edition default, kwarg override, unknown-value fallback, and edition carried on the source record.
