### PR TITLE
docs: add alignment methodology section to ch2 model comparison report

### DIFF
--- a/04_translation_work/ab/antiquitates_ch2/baker_benchmark/model_comparison_report.md
+++ b/04_translation_work/ab/antiquitates_ch2/baker_benchmark/model_comparison_report.md
@@ -62,6 +62,75 @@ floor is reference divergence rather than model failure.
 - `seg_p0050_s0007` — the leonine distich (*Anno trigeno primo…*); Baker
   omits the verse couplet. Our translation covers text his does not.
 
+## Alignment methodology
+
+Baker's 1930 prose and our sentence-level Latin segmentation share no
+common unit — one Ussher sentence can span several short Baker sentences,
+or vice versa — so `baker_align.py` builds the correspondence in four
+deterministic steps, then a final human-patching pass.
+
+1. **Reconstruct continuous Baker text from the scans.** The 44
+   HathiTrust page scans came through as noisy Google OCR text layers.
+   Each page is cleaned before concatenation: strip the trailing page
+   number and the footnote block at the page bottom (detected by a
+   "single-letter marker + citation" line regex), drop OCR noise lines,
+   and re-join words split by end-of-line hyphenation (`be-\nlievers` →
+   `believers`). The 44 cleaned pages are concatenated into one
+   continuous string.
+
+2. **Split Baker into sentences — quote-aware.** A plain split on
+   `.!?` badly under-segments Baker, who (like Ussher) is
+   quotation-dense: a sentence ending inside a closing quote
+   (`…Glaston."`) needs to break there too, or it fuses with the next
+   sentence. The splitter breaks on terminal punctuation whether or not
+   it is wrapped in a closing quote, and skips a small abbreviation list
+   (`St.`, `cap.`, `Lib.`, `Cantab.`, …) so those periods don't trigger
+   false breaks. This mattered in practice — without the quote-aware
+   rule, whole passages merged into mega-sentences and the alignment
+   around the opening pages was visibly wrong on inspection.
+
+3. **Score every candidate (machine-unit, Baker-span) pairing.** For
+   each of the 60 machine units and each contiguous span of up to 24
+   Baker sentences, compute content-word Jaccard similarity (lowercased
+   words ≥3 letters, common stopwords removed) multiplied by a
+   length-balance factor (`min(len)/max(len)` of the two word-sets) so a
+   long span can't win purely by containing more vocabulary — it must
+   also be roughly proportionate in size.
+
+4. **Monotonic dynamic programming picks the alignment.** A DP table
+   where `score[i][j]` is the best cumulative similarity using the
+   first *i* machine units and first *j* Baker sentences; at each step a
+   unit either skips (small penalty, −0.05, for units with no real
+   Baker counterpart) or consumes a span `[j, k)` scored as above.
+   Monotonicity — unit order and Baker-sentence order both strictly
+   increase — enforces that an earlier unit can't be matched to later
+   Baker text than a later unit, which is the correct constraint since
+   both texts follow the same narrative order. Backtracking recovers,
+   for every unit, its matched Baker span.
+
+5. **Human patching of the DP's failure modes.** The automatic pass
+   aligned 58/60 units correctly; the remaining cases needed a person:
+   - Two units have **no Baker counterpart at all** (the chapter
+     argumentum and the leonine-verse couplet — see "Unscored by
+     design" below). The DP correctly left these unaligned; these were
+     confirmed as non-failures and excluded from scoring.
+   - A **footnote citation leaked into a reference span** where a
+     footnote sat mid-page rather than at the page bottom, past the
+     page-cleaner's detection. Found by grepping aligned refs for
+     footnote-citation patterns and manually scrubbed.
+   - A **charter-formula passage** ("In witness whereof, &c. At
+     Westminster…") split across DP boundaries that didn't match how
+     the English units broke it up; re-cut by hand across three
+     adjacent short units.
+
+   Every hand-patch is recorded with a `manual_fix` provenance note
+   directly in `baker_alignment.jsonl` rather than silently folded in.
+
+Steps 1–4 are fully deterministic and reusable: the same
+`baker_alignment.jsonl` scored both Fable and Opus without re-running any
+of this — `baker_score.py --mt-segments` simply swaps in a different
+system's English against the identical aligned references.
+
 ## Artifacts
 
 - `baker_alignment.jsonl` — 58 aligned refs (6 hand-patched records carry


### PR DESCRIPTION
Documents the baker_align.py pipeline in the report itself: OCR-scan cleanup, quote-aware sentence splitting, content-word Jaccard scoring, monotonic DP alignment, and the human-patching pass for the DP's known failure modes (unaligned units, leaked footnote citations, charter-formula boundary mismatch).

## Summary

Describe what changed and why.

## Validation

- [x] Ran tests locally: python -m pytest 08_working_scratch/tests -q
- [x] Added or updated tests as needed

## Impacted Paths

List the main files or folders changed.

## Notes

Anything reviewers should pay special attention to.
